### PR TITLE
Changed the available racks in some munitions

### DIFF
--- a/lua/acf/shared/missiles/arty.lua
+++ b/lua/acf/shared/missiles/arty.lua
@@ -88,7 +88,7 @@ ACF_defineGun("SAKR-10 RA", { --id
 	guidance    = { "Dumb", "Laser", "GPS Guided" },
 	fuses       = { "Contact", "Timed", "Optical", "Cluster" },
 
-	racks       = {["1xRK"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true, ["6xUARRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true, ["6xUARRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
 	agility		= 0.07,
 	viewcone	= 180,

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -135,7 +135,7 @@ ACF_defineGun("AGM-114 ASM", {
 	guidance    = { "Dumb", "Laser", "Active Radar" },
 	fuses       = { "Contact", "Optical" },
 
-	racks       = {["2x AGM-114"] = true, ["4x AGM-114"] = true, ["1xRK"] = true, ["1xRK_small"] = true},
+	racks       = {["2x AGM-114"] = true, ["4x AGM-114"] = true, ["1xRK"] = true},
 
 	viewcone    = 40,
 	seekcone	= 10,
@@ -191,7 +191,7 @@ ACF_defineGun("Ataka ASM", {
 	guidance    = { "Dumb", "Radio (SACLOS)" },
 	fuses       = { "Contact", "Optical" },
 
-	racks       = {["1x Ataka"] = true, ["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1x Ataka"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
 	viewcone    = 45,
 

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -135,7 +135,7 @@ ACF_defineGun("AGM-114 ASM", {
 	guidance    = { "Dumb", "Laser", "Active Radar" },
 	fuses       = { "Contact", "Optical" },
 
-	racks       = {["2x AGM-114"] = true, ["4x AGM-114"] = true, ["1xRK"] = true},
+	racks       = {["2x AGM-114"] = true, ["4x AGM-114"] = true, ["1xRK"] = true, ["1xRK_small"] = true},
 
 	viewcone    = 40,
 	seekcone	= 10,
@@ -191,7 +191,7 @@ ACF_defineGun("Ataka ASM", {
 	guidance    = { "Dumb", "Radio (SACLOS)" },
 	fuses       = { "Contact", "Optical" },
 
-	racks       = {["1x Ataka"] = true, ["1xRK"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1x Ataka"] = true, ["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
 	viewcone    = 45,
 

--- a/lua/acf/shared/missiles/bomb.lua
+++ b/lua/acf/shared/missiles/bomb.lua
@@ -168,7 +168,7 @@ ACF_defineGun("250kgBOMB", { --id
 	guidance    = {"Dumb"},
 	fuses       = {"Contact", "Optical", "Cluster"},
 
-	racks       = {["1xRK"] = true,  ["2xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
 
 	seekcone    = 40,   -- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
@@ -320,6 +320,6 @@ ACF_defineGun("250kgGBOMB", { --id
 	guidance    = {"Dumb"},
 	fuses       = {"Contact", "Optical", "Cluster"},
 
-	racks       = {["1xRK"] = true,  ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 	armdelay    = 1     -- minimum fuse arming delay
 } )

--- a/lua/acf/shared/missiles/bomb.lua
+++ b/lua/acf/shared/missiles/bomb.lua
@@ -320,6 +320,6 @@ ACF_defineGun("250kgGBOMB", { --id
 	guidance    = {"Dumb"},
 	fuses       = {"Contact", "Optical", "Cluster"},
 
-	racks       = {["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true, ["3xRK"] = true, ["4xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true, ["4xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 	armdelay    = 1     -- minimum fuse arming delay
 } )

--- a/lua/acf/shared/missiles/gbu.lua
+++ b/lua/acf/shared/missiles/gbu.lua
@@ -89,7 +89,7 @@ ACF_defineGun("227kgGBU", { --id
 
 	fuses       = {"Contact", "Timed", "Optical", "Cluster"},
 
-	racks       = {["1xRK"] = true,  ["2xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
 	seekcone    = 60,   -- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone    = 80,   -- getting outside this cone will break the lock.  Divided by 2. 
@@ -145,7 +145,7 @@ ACF_defineGun("454kgGBU", { --id
 	guidance    = { "Dumb", "Laser", "GPS Guided" },
 	fuses       = {"Contact", "Timed", "Optical", "Cluster"},
 
-	racks       = {["1xRK"] = true,  ["2xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1xRK"] = true, ["1xRK_small"] = true, ["2xRK"] = true},   -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
 	seekcone    = 60,   -- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone    = 80,   -- getting outside this cone will break the lock.  Divided by 2.

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -178,7 +178,7 @@ ACF_defineGun("S-24 ASR", { --id
 	guidance    = {"Dumb"},
 	fuses       = {"Contact", "Timed"},
 
-	racks       = {["1xRK"] = true, ["3xRK"] = true, ["2xRK"] = true, ["6xUARRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
+	racks       = {["1xRK"] = true, ["1xRK_small"] = true, ["3xRK"] = true, ["2xRK"] = true, ["6xUARRK"] = true},    -- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
 	skinindex   = {HEAT = 0, HE = 1},
 	armdelay    = 0.3     -- minimum fuse arming delay


### PR DESCRIPTION
Added the ability of certain appropriately sized (small) munitions to use the smaller single munition rack:
- 9M120 Ataka
- AGM114 Hellfire
- 250kg bomb 
- 250kg glide bomb
- GBU-12 
- GBU-16
- S-24

Also removed the 3xRK from the 250kg glide bomb for consistency (the regular 250kg can't use it) and because the bombs clip each other.