### PR TITLE
Converted missile burn rate to thrust-specific fuel consumption

### DIFF
--- a/lua/acf/shared/missiles/aam.lua
+++ b/lua/acf/shared/missiles/aam.lua
@@ -30,8 +30,8 @@ ACF.RegisterMissile("AIM-9 AAM", "AAM", {
 		MaxLength		= 35,
 		Armor			= 5,
 		PropMass		= 1,
-		Thrust			= 20000, -- in kg*in/s^2
-		BurnRate		= 500, -- in cm^3/s
+		Thrust			= 20000,	-- in kg*in/s^2
+		FuelConsumption = 0.025,	-- in g/s/f
 		StarterPercent	= 0.1,
 		MinSpeed		= 3000,
 		DragCoef		= 0.002,
@@ -65,8 +65,8 @@ ACF.RegisterMissile("AIM-120 AAM", "AAM", {
 		MaxLength		= 50,
 		Armor			= 5,
 		PropMass		= 2,
-		Thrust			= 24000, -- in kg*in/s^2
-		BurnRate		= 2200, -- in cm^3/s
+		Thrust			= 24000, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,		-- in g/s/f
 		StarterPercent	= 0.3,
 		MinSpeed		= 2000,
 		DragCoef		= 0.002,
@@ -100,8 +100,8 @@ ACF.RegisterMissile("AIM-54 AAM", "AAM", {
 		MaxLength		= 60,
 		Armor			= 5,
 		PropMass		= 5,
-		Thrust			= 45000, -- in kg*in/s^2
-		BurnRate		= 1500, -- in cm^3/s
+		Thrust			= 45000, 	-- in kg*in/s^2
+		FuelConsumption = 0.03,		-- in g/s/f
 		StarterPercent	= 0.1,
 		MinSpeed		= 4000,
 		DragCoef		= 0.005,

--- a/lua/acf/shared/missiles/arm.lua
+++ b/lua/acf/shared/missiles/arm.lua
@@ -30,8 +30,8 @@ ACF.RegisterMissile("AGM-122 ASM", "ARM", {
 		MaxLength		= 70,
 		Armor			= 5,
 		PropMass		= 4,
-		Thrust			= 4500, -- in kg*in/s^2
-		BurnRate		= 1400, -- in cm^3/s
+		Thrust			= 4500,	-- in kg*in/s^2
+		FuelConsumption = 0.3,	-- in g/s/f
 		StarterPercent	= 0.4,
 		MinSpeed		= 5000,
 		DragCoef		= 0.001,
@@ -65,8 +65,8 @@ ACF.RegisterMissile("AGM-45 ASM", "ARM", {
 		MaxLength		= 120,
 		Armor			= 5,
 		PropMass		= 3,
-		Thrust			= 800, -- in kg*in/s^2
-		BurnRate		= 300, -- in cm^3/s
+		Thrust			= 800,	-- in kg*in/s^2
+		FuelConsumption = 0.37,	-- in g/s/f
 		StarterPercent	= 0.05,
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,

--- a/lua/acf/shared/missiles/arty.lua
+++ b/lua/acf/shared/missiles/arty.lua
@@ -30,7 +30,7 @@ ACF.RegisterMissile("Type 63 RA", "ARTY", {
 		Armor			= 5,
 		PropMass		= 0.7,
 		Thrust			= 2400, -- in kg*in/s^2
-		BurnRate		= 400, -- in cm^3/s
+		FuelConsumption = 0.16, -- in g/s/f
 		StarterPercent	= 0.1,
 		MinSpeed		= 200,
 		DragCoef		= 0.002,
@@ -64,7 +64,7 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 		Armor			= 5,
 		PropMass		= 1.2,
 		Thrust			= 1300, -- in kg*in/s^2
-		BurnRate		= 120, -- in cm^3/s
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.1,
 		MinSpeed		= 300,
 		DragCoef		= 0.002,
@@ -97,8 +97,8 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 		MaxLength		= 115,
 		Armor			= 5,
 		PropMass		= 4.0,
-		Thrust			= 850, -- in kg*in/s^2
-		BurnRate		= 200, -- in cm^3/s
+		Thrust			= 850,	-- in kg*in/s^2
+		FuelConsumption = 0.4,	-- in g/s/f
 		StarterPercent	= 0.075,
 		MinSpeed		= 300,
 		DragCoef		= 0.002,

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -29,8 +29,8 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 		MaxLength		= 35,
 		Armor			= 5,
 		PropMass		= 0.2,
-		Thrust			= 8000, -- in kg*in/s^2
-		BurnRate		= 20, -- in cm^3/s
+		Thrust			= 8000, 	-- in kg*in/s^2
+		FuelConsumption = 0.0025,	-- in g/s/f
 		StarterPercent	= 0.2,
 		MinSpeed		= 1500,
 		DragCoef		= 0.005,
@@ -63,7 +63,7 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 		Armor			= 5,
 		PropMass		= 0.2,
 		Thrust			= 13000, -- in kg*in/s^2
-		BurnRate		= 31, -- in cm^3/s
+		FuelConsumption = 0.0025,	-- in g/s/f
 		StarterPercent	= 0.2,
 		MinSpeed		= 2000,
 		DragCoef		= 0.005,
@@ -110,8 +110,8 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 		MaxLength		= 67,
 		Armor			= 5,
 		PropMass		= 0.25,
-		Thrust			= 18000, -- in kg*in/s^2
-		BurnRate		= 80, -- in cm^3/s
+		Thrust			= 18000, 	-- in kg*in/s^2
+		FuelConsumption = 0.0045,	-- in g/s/f
 		StarterPercent	= 0.1,
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,
@@ -147,7 +147,7 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 		Armor			= 5,
 		PropMass		= 0.11,
 		Thrust			= 20000, -- in kg*in/s^2
-		BurnRate		= 300, -- in cm^3/s
+		FuelConsumption = 0.015,	-- in g/s/f
 		StarterPercent	= 0.2,
 		MinSpeed		= 800,
 		DragCoef		= 0.001,
@@ -191,8 +191,8 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		MaxLength		= 70,
 		Armor			= 5,
 		PropMass		= 0.1,
-		Thrust			= 15000, -- in kg*in/s^2
-		BurnRate		= 10, -- in cm^3/s
+		Thrust			= 15000, 	-- in kg*in/s^2
+		FuelConsumption = 0.0007,	-- in g/s/f
 		StarterPercent	= 0.2,
 		MinSpeed		= 8000,
 		DragCoef		= 0.005,
@@ -225,8 +225,8 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 		MaxLength		= 60,
 		Armor			= 5,
 		PropMass		= 0.07,
-		Thrust			= 6000, -- in kg*in/s^2
-		BurnRate		= 9, -- in cm^3/s
+		Thrust			= 6000, 	-- in kg*in/s^2
+		FuelConsumption = 0.0015,	-- in g/s/f
 		StarterPercent	= 0.2,
 		MinSpeed		= 500,
 		DragCoef		= 0.01,

--- a/lua/acf/shared/missiles/bomb.lua
+++ b/lua/acf/shared/missiles/bomb.lua
@@ -29,8 +29,8 @@ ACF.RegisterMissile("50kgBOMB", "BOMB", {
 		MaxLength		= 50,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.01,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
@@ -62,8 +62,8 @@ ACF.RegisterMissile("100kgBOMB", "BOMB", {
 		MaxLength		= 100,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
@@ -95,8 +95,8 @@ ACF.RegisterMissile("250kgBOMB", "BOMB", {
 		MaxLength		= 250,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
@@ -128,8 +128,8 @@ ACF.RegisterMissile("500kgBOMB", "BOMB", {
 		MaxLength		= 200,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
@@ -161,8 +161,8 @@ ACF.RegisterMissile("1000kgBOMB", "BOMB", {
 		MaxLength		= 375,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,

--- a/lua/acf/shared/missiles/ffar.lua
+++ b/lua/acf/shared/missiles/ffar.lua
@@ -27,8 +27,8 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 		MaxLength		= 25,
 		Armor			= 5,
 		PropMass		= 0.2,
-		Thrust			= 10000, -- in kg*in/s^2
-		BurnRate		= 120, -- in cm^3/s
+		Thrust			= 10000, 	-- in kg*in/s^2
+		FuelConsumption = 0.012,	-- in g/s/f
 		StarterPercent	= 0.15,
 		MinSpeed		= 5000,
 		DragCoef		= 0.001,
@@ -60,8 +60,8 @@ ACF.RegisterMissile("70mmFFAR", "FFAR", {
 		MaxLength		= 25,
 		Armor			= 5,
 		PropMass		= 0.7,
-		Thrust			= 15000, -- in kg*in/s^2
-		BurnRate		= 300, -- in cm^3/s
+		Thrust			= 15000,	-- in kg*in/s^2
+		FuelConsumption = 0.02,		-- in g/s/f
 		StarterPercent	= 0.15,
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,
@@ -93,8 +93,8 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		MaxLength		= 60,
 		Armor			= 5,
 		PropMass		= 0.7,
-		Thrust			= 18000, -- in kg*in/s^2
-		BurnRate		= 600, -- in cm^3/s
+		Thrust			= 18000, 	-- in kg*in/s^2
+		FuelConsumption = 0.03,		-- in g/s/f
 		StarterPercent	= 0.15,
 		MinSpeed		= 6000,
 		DragCoef		= 0.001,

--- a/lua/acf/shared/missiles/gbomb.lua
+++ b/lua/acf/shared/missiles/gbomb.lua
@@ -26,8 +26,8 @@ ACF.RegisterMissile("100kgGBOMB", "GBOMB", {
 		MaxLength		= 100,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
 		DragCoef		= 0.0001,
@@ -57,8 +57,8 @@ ACF.RegisterMissile("250kgGBOMB", "GBOMB", {
 		MaxLength		= 250,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
 		DragCoef		= 0.001,

--- a/lua/acf/shared/missiles/gbu.lua
+++ b/lua/acf/shared/missiles/gbu.lua
@@ -30,8 +30,8 @@ ACF.RegisterMissile("WalleyeGBU", "GBU", {
 		MaxLength		= 80,
 		Armor			= 10,
 		PropMass		= 1,
-		Thrust			= 1,
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1,	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
 		DragCoef		= 0.00001,
@@ -81,8 +81,8 @@ ACF.RegisterMissile("227kgGBU", "GBU", {
 		MaxLength		= 250,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
@@ -131,8 +131,8 @@ ACF.RegisterMissile("454kgGBU", "GBU", {
 		MaxLength		= 500,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
@@ -182,8 +182,8 @@ ACF.RegisterMissile("909kgGBU", "GBU", {
 		MaxLength		= 510,
 		Armor			= 10,
 		PropMass		= 0,
-		Thrust			= 1, -- in kg*in/s^2
-		BurnRate		= 1, -- in cm^3/s
+		Thrust			= 1, 	-- in kg*in/s^2
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,

--- a/lua/acf/shared/missiles/sam.lua
+++ b/lua/acf/shared/missiles/sam.lua
@@ -31,7 +31,7 @@ ACF.RegisterMissile("FIM-92 SAM", "SAM", {
 		Armor			= 5,
 		PropMass		= 1.5,
 		Thrust			= 7000, -- in kg*in/s^2
-		BurnRate		= 1000, -- in cm^3/s
+		FuelConsumption = 0.14,	-- in g/s/f
 		StarterPercent	= 0.3,
 		MinSpeed		= 3000,
 		DragCoef		= 0.001,
@@ -65,7 +65,7 @@ ACF.RegisterMissile("Strela-1 SAM", "SAM", {
 		Armor			= 5,
 		PropMass		= 1,
 		Thrust			= 4000, -- in kg*in/s^2
-		BurnRate		= 400, -- in cm^3/s
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.1,
 		MinSpeed		= 4000,
 		DragCoef		= 0.003,

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -41,8 +41,8 @@ ACF.RegisterMissile("RS82 ASR", "UAR", {
 		MaxLength		= 25,
 		Armor			= 5,
 		PropMass		= 0.7,
-		Thrust			= 15000, -- in kg*in/s^2
-		BurnRate		= 800, -- in cm^3/s
+		Thrust			= 15000,	-- in kg*in/s^2
+		FuelConsumption = 0.05,		-- in g/s/f
 		StarterPercent	= 0.15,
 		MinSpeed		= 6000,
 		DragCoef		= 0.002,
@@ -75,8 +75,8 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 		MaxLength		= 25,
 		Armor			= 5,
 		PropMass		= 0.7,
-		Thrust			= 25000, -- in kg*in/s^2
-		BurnRate		= 600, -- in cm^3/s
+		Thrust			= 25000,	-- in kg*in/s^2
+		FuelConsumption = 0.024,	-- in g/s/f
 		StarterPercent	= 0.15,
 		MinSpeed		= 5000,
 		DragCoef		= 0.002,
@@ -107,8 +107,8 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 		MaxLength		= 50,
 		Armor			= 5,
 		PropMass		= 0.5,
-		Thrust			= 120000, -- in kg*in/s^2 very high but only burns a brief moment, most of which is in the tube
-		BurnRate		= 1200, -- in cm^3/s
+		Thrust			= 120000,	-- in kg*in/s^2 very high but only burns a brief moment, most of which is in the tube
+		FuelConsumption = 0.01,		-- in g/s/f
 		StarterPercent	= 0.72,
 		MinSpeed		= 900,
 		DragCoefFlight	= 0.05,
@@ -141,7 +141,7 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 		Armor			= 5,
 		PropMass		= 15,
 		Thrust			= 9000, -- in kg*in/s^2
-		BurnRate		= 1000, -- in cm^3/s
+		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.15,
 		MinSpeed		= 10000,
 		DragCoef		= 0.001,
@@ -176,7 +176,7 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 		Armor			= 5,
 		PropMass		= 5,
 		Thrust			= 5000, -- in kg*in/s^2
-		BurnRate		= 5000, -- in cm^3/s
+		FuelConsumption = 1,	-- in g/s/f
 		StarterPercent	= 0.01,
 		MinSpeed		= 1,
 		DragCoef		= 0,

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -328,47 +328,47 @@ function MakeACF_Missile(Player, Pos, Ang, Rack, MountPoint, Crate)
 	Missile:SetParent(Rack)
 	Missile:Spawn()
 
-	Missile.Owner          = Player
-	Missile.Name           = Data.Name
-	Missile.ShortName      = Data.ID
-	Missile.EntType        = Class.Name
-	Missile.Caliber        = Caliber
-	Missile.Launcher       = Rack
-	Missile.MountPoint     = MountPoint
-	Missile.Filter         = { Rack }
-	Missile.SeekCone       = Data.SeekCone
-	Missile.ViewCone       = Data.ViewCone
-	Missile.SkinIndex      = Data.SkinIndex
-	Missile.NoThrust       = Data.NoThrust or Class.NoThrust
-	Missile.Sound          = Data.Sound or Class.Sound or "acf_missiles/missiles/missile_rocket.mp3"
-	Missile.ReloadTime     = Data.ReloadTime or 10
-	Missile.ForcedMass     = Data.Mass or 10
-	Missile.ForcedArmor    = Round.Armor
-	Missile.Effect         = Data.Effect or Class.Effect
-	Missile.NoDamage       = Rack.ProtectMissile or Data.NoDamage
-	Missile.ExhaustOffset  = Data.ExhaustOffset
-	Missile.Bodygroups     = Data.Bodygroups
-	Missile.RackModel      = Rack.MissileModel or Round.RackModel
-	Missile.RealModel      = Round.Model
-	Missile.DragCoef       = Round.DragCoef
-	Missile.DragCoefFlight = Round.DragCoefFlight or Round.DragCoef
-	Missile.MinimumSpeed   = Round.MinSpeed
-	Missile.MaxThrust      = Round.Thrust
-	Missile.BurnRate       = Round.BurnRate * 0.001
-	Missile.StarterPercent = Round.StarterPercent
-	Missile.FinMultiplier  = Round.FinMul
-	Missile.CanDelay       = Round.CanDelayLaunch
-	Missile.MaxLength      = Round.MaxLength
-	Missile.Agility        = Data.Agility or 1
-	Missile.Inertia        = 0.08333 * Data.Mass * (3.1416 * (Caliber * 0.05) ^ 2 + Length)
-	Missile.Length         = Length
-	Missile.TorqueMul      = Length * 25
-	Missile.RotAxis        = Vector()
-	Missile.UseGuidance    = true
-	Missile.MotorEnabled   = false
-	Missile.Thrust         = 0
-	Missile.ThinkDelay     = 0.1
-	Missile.Inputs         = WireLib.CreateInputs(Missile, { "Detonate" })
+	Missile.Owner          	= Player
+	Missile.Name           	= Data.Name
+	Missile.ShortName      	= Data.ID
+	Missile.EntType        	= Class.Name
+	Missile.Caliber        	= Caliber
+	Missile.Launcher       	= Rack
+	Missile.MountPoint     	= MountPoint
+	Missile.Filter         	= { Rack }
+	Missile.SeekCone       	= Data.SeekCone
+	Missile.ViewCone       	= Data.ViewCone
+	Missile.SkinIndex      	= Data.SkinIndex
+	Missile.NoThrust       	= Data.NoThrust or Class.NoThrust
+	Missile.Sound          	= Data.Sound or Class.Sound or "acf_missiles/missiles/missile_rocket.mp3"
+	Missile.ReloadTime     	= Data.ReloadTime or 10
+	Missile.ForcedMass     	= Data.Mass or 10
+	Missile.ForcedArmor    	= Round.Armor
+	Missile.Effect         	= Data.Effect or Class.Effect
+	Missile.NoDamage       	= Rack.ProtectMissile or Data.NoDamage
+	Missile.ExhaustOffset  	= Data.ExhaustOffset
+	Missile.Bodygroups     	= Data.Bodygroups
+	Missile.RackModel      	= Rack.MissileModel or Round.RackModel
+	Missile.RealModel      	= Round.Model
+	Missile.DragCoef       	= Round.DragCoef
+	Missile.DragCoefFlight 	= Round.DragCoefFlight or Round.DragCoef
+	Missile.MinimumSpeed   	= Round.MinSpeed
+	Missile.MaxThrust      	= Round.Thrust
+	Missile.FuelConsumption	= Round.FuelConsumption * 0.001
+	Missile.StarterPercent 	= Round.StarterPercent
+	Missile.FinMultiplier  	= Round.FinMul
+	Missile.CanDelay       	= Round.CanDelayLaunch
+	Missile.MaxLength      	= Round.MaxLength
+	Missile.Agility        	= Data.Agility or 1
+	Missile.Inertia        	= 0.08333 * Data.Mass * (3.1416 * (Caliber * 0.05) ^ 2 + Length)
+	Missile.Length         	= Length
+	Missile.TorqueMul      	= Length * 25
+	Missile.RotAxis        	= Vector()
+	Missile.UseGuidance    	= true
+	Missile.MotorEnabled   	= false
+	Missile.Thrust         	= 0
+	Missile.ThinkDelay     	= 0.1
+	Missile.Inputs         	= WireLib.CreateInputs(Missile, { "Detonate" })
 
 	Missile:UpdateModel(Missile.RackModel or Missile.RealModel)
 	Missile:CreateBulletData(Crate)
@@ -381,7 +381,7 @@ function MakeACF_Missile(Player, Pos, Ang, Rack, MountPoint, Crate)
 	if Missile.NoThrust then
 		Missile.MotorLength = 0
 	else
-		Missile.MotorLength = Missile.BulletData.PropMass / Missile.BurnRate * (1 - Missile.StarterPercent)
+		Missile.MotorLength = (1 - Missile.StarterPercent) * Missile.BulletData.PropMass / (Missile.FuelConsumption * Missile.MaxThrust)
 	end
 
 	do -- Exhaust pos


### PR DESCRIPTION
Missiles currently have both thrust and burn rate. To get a measure of their efficiency, you need to establish a ratio between these values. This makes it hard to get a feel for missile fuel efficiency.

This converts the burn rate to a thrust-specific fuel consumption (the fuel consumption rate (grams per second) per unit of thrust (kg inch per second squared), or g/s/f, where f is the unit of thrust used), which immediately gives away how efficient the rocket motors are. This should help with balancing and with creating more missiles inline with the existing ones.

Turns out the motors have efficiencies ranging from 0.0007 to 1, meaning some are more than 1000x more efficient than others. I suggest the fuel consumption get normalized in the future. and all missiles get brought to more or less the same standard. The exact value needs some researching, but I believe motors shouldn't be more than 10 or so times more efficient than others, seeing as they're all probably solid rocket motors. This means a lot of re-balancing of course, where the best missiles would at least need to carry more fuel, and the worst ones could do with less. Regardless, that part is for a later commit.