### PR TITLE
Fixed missile starter percentage and rack velocity inheritance

### DIFF
--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -138,7 +138,7 @@ local function CalcFlight(Missile)
 	local Dir = Missile.CurDir
 	local LastVel = Missile.LastVel
 	local LastSpeed = LastVel:Length()
-	local VelNorm = LastVel / LastSpeed
+	local VelNorm = LastVel:GetNormalized()
 
 	Missile.LastThink = Time
 

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -379,10 +379,13 @@ function MakeACF_Missile(Player, Pos, Ang, Rack, MountPoint, Crate)
 	end
 
 	if Missile.NoThrust then
-		Missile.MotorLength = 0
-	else
-		Missile.MotorLength = (1 - Missile.StarterPercent) * Missile.BulletData.PropMass / (Missile.FuelConsumption * Missile.MaxThrust)
-	end
+        Missile.MotorLength = 0
+        Missile.SpeedBoost = 0
+    else
+        local TotalLength = Missile.BulletData.PropMass / (Missile.FuelConsumption * Missile.MaxThrust)
+        Missile.MotorLength = (1 - Missile.StarterPercent) * TotalLength
+        Missile.SpeedBoost = Missile.StarterPercent * TotalLength * Missile.MaxThrust
+    end
 
 	do -- Exhaust pos
 		local Attachment = Missile:GetAttachment(Missile:LookupAttachment("exhaust"))
@@ -446,7 +449,7 @@ function ENT:Launch(Delay, IsMisfire)
 	local Point      = self.MountPoint
 	local Rack       = self.Launcher
 	local Flight     = BulletData.Flight or self:LocalToWorldAngles(Point.Angle):Forward()
-	local Velocity   = Flight + (Rack.Velocity:Length() * Flight)
+    local Velocity = Rack.Velocity + self.SpeedBoost * Flight
 	local DeltaTime  = engine.TickInterval()
 
 	if Rack.SoundPath and Rack.SoundPath ~= "" then

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -379,13 +379,14 @@ function MakeACF_Missile(Player, Pos, Ang, Rack, MountPoint, Crate)
 	end
 
 	if Missile.NoThrust then
-        Missile.MotorLength = 0
-        Missile.SpeedBoost = 0
-    else
-        local TotalLength = Missile.BulletData.PropMass / (Missile.FuelConsumption * Missile.MaxThrust)
-        Missile.MotorLength = (1 - Missile.StarterPercent) * TotalLength
-        Missile.SpeedBoost = Missile.StarterPercent * TotalLength * Missile.MaxThrust
-    end
+		Missile.MotorLength = 0
+		Missile.SpeedBoost = 0
+	else
+		local TotalLength = Missile.BulletData.PropMass / (Missile.FuelConsumption * Missile.MaxThrust)
+
+		Missile.MotorLength = (1 - Missile.StarterPercent) * TotalLength
+		Missile.SpeedBoost = Missile.StarterPercent * TotalLength * Missile.MaxThrust
+	end
 
 	do -- Exhaust pos
 		local Attachment = Missile:GetAttachment(Missile:LookupAttachment("exhaust"))
@@ -449,7 +450,7 @@ function ENT:Launch(Delay, IsMisfire)
 	local Point      = self.MountPoint
 	local Rack       = self.Launcher
 	local Flight     = BulletData.Flight or self:LocalToWorldAngles(Point.Angle):Forward()
-    local Velocity = Rack.Velocity + self.SpeedBoost * Flight
+	local Velocity   = Rack.Velocity + self.SpeedBoost * Flight
 	local DeltaTime  = engine.TickInterval()
 
 	if Rack.SoundPath and Rack.SoundPath ~= "" then


### PR DESCRIPTION
This makes it so the starter percentage actually has an effect on missiles besides just taking away fuel from the motor, which was stunting some missiles like the UAR recoilless guns. 

With this, missiles can also now properly inherit the velocity of the parent rack. Before they would take the rack's velocity and multiply its length to the rack's forward vector. Now it correctly takes the rack's velocity, with a forward velocity boost dependent on the starter. Below is an example on how the starter percentage allows the velocity to be inherited:

https://user-images.githubusercontent.com/37046867/107878475-df13d480-6eca-11eb-9f77-7db4cee829ef.mp4

The first rocket has 0% starter, the second 10%, and the last 75%. Even a small amount such as 10% allows it to go in the correct direction, while still being slightly affected by the rack's movement. Because of this I left the starter percentages in all missiles as-is. 