### PR TITLE
Corrected lift coefficient scaling and sign

### DIFF
--- a/lua/acf/shared/missiles/aam.lua
+++ b/lua/acf/shared/missiles/aam.lua
@@ -36,7 +36,7 @@ ACF.RegisterMissile("AIM-9 AAM", "AAM", {
 		MinSpeed		= 3000,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.03,
-		FinMul			= 0.025,
+		FinMul			= 1.25,
 		CanDelayLaunch	= true,
 		ActualLength 	= 85,
 		ActualWidth		= 4.3
@@ -71,7 +71,7 @@ ACF.RegisterMissile("AIM-120 AAM", "AAM", {
 		MinSpeed		= 2000,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.0013,
-		FinMul			= 0.027,
+		FinMul			= 1.62,
 		CanDelayLaunch	= true,
 		ActualLength 	= 129.5,
 		ActualWidth		= 6.8
@@ -106,7 +106,7 @@ ACF.RegisterMissile("AIM-54 AAM", "AAM", {
 		MinSpeed		= 4000,
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.05,
-		FinMul			= 0.02,
+		FinMul			= 1.2,
 		CanDelayLaunch	= true,
 		ActualLength 	= 139.5,
 		ActualWidth		= 13.5

--- a/lua/acf/shared/missiles/arm.lua
+++ b/lua/acf/shared/missiles/arm.lua
@@ -36,7 +36,7 @@ ACF.RegisterMissile("AGM-122 ASM", "ARM", {
 		MinSpeed		= 5000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.001,
-		FinMul			= 0.03,
+		FinMul			= 1.8,
 		CanDelayLaunch	= true,
 		ActualLength 	= 85,
 		ActualWidth		= 4.2
@@ -71,7 +71,7 @@ ACF.RegisterMissile("AGM-45 ASM", "ARM", {
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0,
-		FinMul			= 0.2,
+		FinMul			= 12,
 		CanDelayLaunch	= true,
 		ActualLength 	= 151.5,
 		ActualWidth		= 7.1

--- a/lua/acf/shared/missiles/arty.lua
+++ b/lua/acf/shared/missiles/arty.lua
@@ -35,7 +35,7 @@ ACF.RegisterMissile("Type 63 RA", "ARTY", {
 		MinSpeed		= 200,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.001,
-		FinMul			= 0.02,
+		FinMul			= 1.2,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 50,
 		ActualWidth		= 7.2
@@ -69,7 +69,7 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 		MinSpeed		= 300,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.010,
-		FinMul			= 0.03,
+		FinMul			= 1.8,
 		PenMul			= math.sqrt(1.1),
 		ActualLength 	= 86.5,
 		ActualWidth		= 5.5
@@ -103,7 +103,7 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 		MinSpeed		= 300,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.009,
-		FinMul			= 0.05,
+		FinMul			= 3,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 151.5,
 		ActualWidth		= 7.1

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -35,7 +35,7 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 		MinSpeed		= 1500,
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.1,
-		FinMul			= 0.1,
+		FinMul			= 6,
 		PenMul			= math.sqrt(5.39),
 		ActualLength 	= 34.5,
 		ActualWidth		= 5.2
@@ -68,7 +68,7 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 		MinSpeed		= 2000,
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.05,
-		FinMul			= 0.05,
+		FinMul			= 3,
 		PenMul			= math.sqrt(3.97),
 		ActualLength 	= 59,
 		ActualWidth		= 5.9
@@ -116,7 +116,7 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.05,
-		FinMul			= 0.05,
+		FinMul			= 3,
 		PenMul			= math.sqrt(4.175),
 		ActualLength 	= 64.7,
 		ActualWidth		= 7.9
@@ -152,7 +152,7 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 		MinSpeed		= 800,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.04,
-		FinMul			= 0.05,
+		FinMul			= 3,
 		PenMul			= math.sqrt(1.454),
 		ActualLength 	= 68.5,
 		ActualWidth		= 5.2
@@ -197,7 +197,7 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		MinSpeed		= 8000,
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.05,
-		FinMul			= 0.05,
+		FinMul			= 3,
 		PenMul			= math.sqrt(4.2),
 		ActualLength 	= 55.3,
 		ActualWidth		= 7
@@ -231,7 +231,7 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 		MinSpeed		= 500,
 		DragCoef		= 0.01,
 		DragCoefFlight	= 0.04,
-		FinMul			= 0.1,
+		FinMul			= 6,
 		PenMul			= math.sqrt(3.025),
 		ActualLength 	= 45.5,
 		ActualWidth		= 5.5

--- a/lua/acf/shared/missiles/bomb.lua
+++ b/lua/acf/shared/missiles/bomb.lua
@@ -34,7 +34,7 @@ ACF.RegisterMissile("50kgBOMB", "BOMB", {
 		StarterPercent	= 0.01,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
-		FinMul			= 0.008,
+		FinMul			= 0.48,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 37,
 		ActualWidth		= 9.2
@@ -67,7 +67,7 @@ ACF.RegisterMissile("100kgBOMB", "BOMB", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
-		FinMul			= 0.007,
+		FinMul			= 0.42,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 44,
 		ActualWidth		= 12
@@ -100,7 +100,7 @@ ACF.RegisterMissile("250kgBOMB", "BOMB", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
-		FinMul			= 0.005,
+		FinMul			= 0.3,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 83,
 		ActualWidth		= 14.5
@@ -133,7 +133,7 @@ ACF.RegisterMissile("500kgBOMB", "BOMB", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
-		FinMul			= 0.004,
+		FinMul			= 0.24,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 85,
 		ActualWidth		= 17.5
@@ -166,7 +166,7 @@ ACF.RegisterMissile("1000kgBOMB", "BOMB", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
-		FinMul			= 0.004,
+		FinMul			= 0.24,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 90.5,
 		ActualWidth		= 22.7

--- a/lua/acf/shared/missiles/ffar.lua
+++ b/lua/acf/shared/missiles/ffar.lua
@@ -33,7 +33,7 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 		MinSpeed		= 5000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,
-		FinMul			= 0.003,
+		FinMul			= 0.18,
 		PenMul			= math.sqrt(4),
 		ActualLength 	= 26.5,
 		ActualWidth		= 1.6
@@ -66,7 +66,7 @@ ACF.RegisterMissile("70mmFFAR", "FFAR", {
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,
-		FinMul			= 0.015,
+		FinMul			= 0.9,
 		PenMul			= math.sqrt(6),
 		ActualLength 	= 46,
 		ActualWidth		= 2.6
@@ -99,7 +99,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		MinSpeed		= 6000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,
-		FinMul			= 0.015,
+		FinMul			= 0.9,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 118,
 		ActualWidth		= 4.8

--- a/lua/acf/shared/missiles/gbomb.lua
+++ b/lua/acf/shared/missiles/gbomb.lua
@@ -31,7 +31,7 @@ ACF.RegisterMissile("100kgGBOMB", "GBOMB", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
 		DragCoef		= 0.0001,
-		FinMul			= 0.05,
+		FinMul			= 3,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 50,
 		ActualWidth		= 11.4
@@ -62,7 +62,7 @@ ACF.RegisterMissile("250kgGBOMB", "GBOMB", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
 		DragCoef		= 0.001,
-		FinMul			= 0.05,
+		FinMul			= 3,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 67,
 		ActualWidth		= 15

--- a/lua/acf/shared/missiles/gbu.lua
+++ b/lua/acf/shared/missiles/gbu.lua
@@ -35,7 +35,7 @@ ACF.RegisterMissile("WalleyeGBU", "GBU", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
 		DragCoef		= 0.00001,
-		FinMul			= 0.02,
+		FinMul			= 1.2,
 		PenMul			= math.sqrt(0.5),
 		ActualLength 	= 137,
 		ActualWidth		= 16
@@ -86,7 +86,7 @@ ACF.RegisterMissile("227kgGBU", "GBU", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
-		FinMul			= 0.02,
+		FinMul			= 1.2,
 		PenMul			= math.sqrt(0.4),
 		ActualLength 	= 86.8,
 		ActualWidth		= 9.5
@@ -136,7 +136,7 @@ ACF.RegisterMissile("454kgGBU", "GBU", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
-		FinMul			= 0.02,
+		FinMul			= 1.2,
 		PenMul			= math.sqrt(0.3),
 		ActualLength 	= 101.5,
 		ActualWidth		= 12.2
@@ -187,7 +187,7 @@ ACF.RegisterMissile("909kgGBU", "GBU", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
-		FinMul			= 0.01,
+		FinMul			= 0.6,
 		PenMul			= math.sqrt(0.2),
 		ActualLength 	= 126.1,
 		ActualWidth		= 17.8

--- a/lua/acf/shared/missiles/sam.lua
+++ b/lua/acf/shared/missiles/sam.lua
@@ -36,7 +36,7 @@ ACF.RegisterMissile("FIM-92 SAM", "SAM", {
 		MinSpeed		= 3000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.0001,
-		FinMul			= 0.02,
+		FinMul			= 1.2,
 		ActualLength 	= 59,
 		ActualWidth		= 2.7
 	},
@@ -70,7 +70,7 @@ ACF.RegisterMissile("Strela-1 SAM", "SAM", {
 		MinSpeed		= 4000,
 		DragCoef		= 0.003,
 		DragCoefFlight	= 0,
-		FinMul			= 0.03,
+		FinMul			= 1.8,
 		ActualLength 	= 86.5,
 		ActualWidth		= 5.5
 	},

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -47,7 +47,7 @@ ACF.RegisterMissile("RS82 ASR", "UAR", {
 		MinSpeed		= 6000,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.025,
-		FinMul			= 0.008,
+		FinMul			= 4.8,
 		PenMul			= math.sqrt(6.63),
 		ActualLength 	= 25.2,
 		ActualWidth		= 3
@@ -81,7 +81,7 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 		MinSpeed		= 5000,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.02,
-		FinMul			= 0.01,
+		FinMul			= 0.6,
 		PenMul			= math.sqrt(6.25),
 		ActualLength 	= 69, -- nice
 		ActualWidth		= 5
@@ -113,7 +113,7 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 		MinSpeed		= 900,
 		DragCoefFlight	= 0.05,
 		DragCoef		= 0.001,
-		FinMul			= 0.02,
+		FinMul			= 1.2,
 		PenMul			= math.sqrt(4.5),
 		ActualLength 	= 25.4,
 		ActualWidth		= 4.2
@@ -146,7 +146,7 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 		MinSpeed		= 10000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.01,
-		FinMul			= 0.02,
+		FinMul			= 1.2,
 		PenMul			= math.sqrt(5),
 		ActualLength 	= 89.3,
 		ActualWidth		= 9
@@ -180,7 +180,7 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 		StarterPercent	= 0.01,
 		MinSpeed		= 1,
 		DragCoef		= 0,
-		FinMul			= 0.001,
+		FinMul			= 0.06,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 65,
 		ActualWidth		= 16.4

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -225,7 +225,7 @@ local function CalcFlight(Missile)
 
 	local Up = Dir:Cross(LastVel):Cross(Dir):GetNormalized()
 	local DotSimple = Up.x * VelNorm.x + Up.y * VelNorm.y + Up.z * VelNorm.z
-	local Lift = Up * LastSpeed * DotSimple * Missile.FinMultiplier
+	local Lift = -Up * LastSpeed * DotSimple * Missile.FinMultiplier
 
 	local DragCoef = Missile.MotorEnabled and Missile.DragCoefFlight or Missile.DragCoef
 	local Drag = LastVel * (DragCoef * LastSpeed) / ACF.DragDiv * ACF.Scale


### PR DESCRIPTION
This is a followup on #22 , where I made a mistake in the sign and scaling of the lift. This corrects both. The fin multiplier had to be corrected (scaled by 60x) as it previously did not account for the tick rate. This time I tested everything and everything flies identically to how it used to.