### PR TITLE
Rebalanced starter percentages for all missiles

### DIFF
--- a/lua/acf/shared/missiles/aam.lua
+++ b/lua/acf/shared/missiles/aam.lua
@@ -32,7 +32,7 @@ ACF.RegisterMissile("AIM-9 AAM", "AAM", {
 		PropMass		= 1,
 		Thrust			= 20000,	-- in kg*in/s^2
 		FuelConsumption = 0.025,	-- in g/s/f
-		StarterPercent	= 0.1,
+		StarterPercent	= 0.05,
 		MinSpeed		= 3000,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.03,
@@ -67,7 +67,7 @@ ACF.RegisterMissile("AIM-120 AAM", "AAM", {
 		PropMass		= 2,
 		Thrust			= 24000, 	-- in kg*in/s^2
 		FuelConsumption = 0.1,		-- in g/s/f
-		StarterPercent	= 0.3,
+		StarterPercent	= 0.05,
 		MinSpeed		= 2000,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.0013,
@@ -102,7 +102,7 @@ ACF.RegisterMissile("AIM-54 AAM", "AAM", {
 		PropMass		= 5,
 		Thrust			= 45000, 	-- in kg*in/s^2
 		FuelConsumption = 0.03,		-- in g/s/f
-		StarterPercent	= 0.1,
+		StarterPercent	= 0.002,
 		MinSpeed		= 4000,
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.05,

--- a/lua/acf/shared/missiles/arm.lua
+++ b/lua/acf/shared/missiles/arm.lua
@@ -32,7 +32,7 @@ ACF.RegisterMissile("AGM-122 ASM", "ARM", {
 		PropMass		= 4,
 		Thrust			= 4500,	-- in kg*in/s^2
 		FuelConsumption = 0.3,	-- in g/s/f
-		StarterPercent	= 0.4,
+		StarterPercent	= 0.1,
 		MinSpeed		= 5000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.001,
@@ -67,7 +67,7 @@ ACF.RegisterMissile("AGM-45 ASM", "ARM", {
 		PropMass		= 3,
 		Thrust			= 800,	-- in kg*in/s^2
 		FuelConsumption = 0.37,	-- in g/s/f
-		StarterPercent	= 0.05,
+		StarterPercent	= 0.07,
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0,

--- a/lua/acf/shared/missiles/arty.lua
+++ b/lua/acf/shared/missiles/arty.lua
@@ -31,7 +31,7 @@ ACF.RegisterMissile("Type 63 RA", "ARTY", {
 		PropMass		= 0.7,
 		Thrust			= 2400, -- in kg*in/s^2
 		FuelConsumption = 0.16, -- in g/s/f
-		StarterPercent	= 0.1,
+		StarterPercent	= 0.05,
 		MinSpeed		= 200,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.001,
@@ -65,7 +65,7 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 		PropMass		= 1.2,
 		Thrust			= 1300, -- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
-		StarterPercent	= 0.1,
+		StarterPercent	= 0.05,
 		MinSpeed		= 300,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.010,
@@ -99,7 +99,7 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 		PropMass		= 4.0,
 		Thrust			= 850,	-- in kg*in/s^2
 		FuelConsumption = 0.4,	-- in g/s/f
-		StarterPercent	= 0.075,
+		StarterPercent	= 0.05,
 		MinSpeed		= 300,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.009,

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -191,12 +191,12 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		MaxLength		= 70,
 		Armor			= 5,
 		PropMass		= 0.1,
-		Thrust			= 15000, 	-- in kg*in/s^2
-		FuelConsumption = 0.0007,	-- in g/s/f
+		Thrust			= 25000, 	-- in kg*in/s^2
+		FuelConsumption = 0.001,	-- in g/s/f
 		StarterPercent	= 0.002,
 		MinSpeed		= 8000,
-		DragCoef		= 0.005,
-		DragCoefFlight	= 0.05,
+		DragCoef		= 0.002,
+		DragCoefFlight	= 0.02,
 		FinMul			= 3,
 		PenMul			= math.sqrt(4.2),
 		ActualLength 	= 55.3,

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -31,7 +31,7 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 		PropMass		= 0.2,
 		Thrust			= 8000, 	-- in kg*in/s^2
 		FuelConsumption = 0.0025,	-- in g/s/f
-		StarterPercent	= 0.2,
+		StarterPercent	= 0.005,
 		MinSpeed		= 1500,
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.1,
@@ -64,7 +64,7 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 		PropMass		= 0.2,
 		Thrust			= 13000, -- in kg*in/s^2
 		FuelConsumption = 0.0025,	-- in g/s/f
-		StarterPercent	= 0.2,
+		StarterPercent	= 0.003,
 		MinSpeed		= 2000,
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.05,
@@ -112,7 +112,7 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 		PropMass		= 0.25,
 		Thrust			= 18000, 	-- in kg*in/s^2
 		FuelConsumption = 0.0045,	-- in g/s/f
-		StarterPercent	= 0.1,
+		StarterPercent	= 0.005,
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.05,
@@ -148,7 +148,7 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 		PropMass		= 0.11,
 		Thrust			= 20000, -- in kg*in/s^2
 		FuelConsumption = 0.015,	-- in g/s/f
-		StarterPercent	= 0.2,
+		StarterPercent	= 0.04,
 		MinSpeed		= 800,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.04,
@@ -193,7 +193,7 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		PropMass		= 0.1,
 		Thrust			= 15000, 	-- in kg*in/s^2
 		FuelConsumption = 0.0007,	-- in g/s/f
-		StarterPercent	= 0.2,
+		StarterPercent	= 0.002,
 		MinSpeed		= 8000,
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.05,
@@ -227,7 +227,7 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 		PropMass		= 0.07,
 		Thrust			= 6000, 	-- in kg*in/s^2
 		FuelConsumption = 0.0015,	-- in g/s/f
-		StarterPercent	= 0.2,
+		StarterPercent	= 0.004,
 		MinSpeed		= 500,
 		DragCoef		= 0.01,
 		DragCoefFlight	= 0.04,

--- a/lua/acf/shared/missiles/ffar.lua
+++ b/lua/acf/shared/missiles/ffar.lua
@@ -29,7 +29,7 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 		PropMass		= 0.2,
 		Thrust			= 10000, 	-- in kg*in/s^2
 		FuelConsumption = 0.012,	-- in g/s/f
-		StarterPercent	= 0.15,
+		StarterPercent	= 0.1,
 		MinSpeed		= 5000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,
@@ -62,7 +62,7 @@ ACF.RegisterMissile("70mmFFAR", "FFAR", {
 		PropMass		= 0.7,
 		Thrust			= 15000,	-- in kg*in/s^2
 		FuelConsumption = 0.02,		-- in g/s/f
-		StarterPercent	= 0.15,
+		StarterPercent	= 0.05,
 		MinSpeed		= 4000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,
@@ -95,7 +95,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		PropMass		= 0.7,
 		Thrust			= 18000, 	-- in kg*in/s^2
 		FuelConsumption = 0.03,		-- in g/s/f
-		StarterPercent	= 0.15,
+		StarterPercent	= 0.05,
 		MinSpeed		= 6000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,

--- a/lua/acf/shared/missiles/sam.lua
+++ b/lua/acf/shared/missiles/sam.lua
@@ -32,7 +32,7 @@ ACF.RegisterMissile("FIM-92 SAM", "SAM", {
 		PropMass		= 1.5,
 		Thrust			= 7000, -- in kg*in/s^2
 		FuelConsumption = 0.14,	-- in g/s/f
-		StarterPercent	= 0.3,
+		StarterPercent	= 0.1,
 		MinSpeed		= 3000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.0001,

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -107,12 +107,12 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 		MaxLength		= 50,
 		Armor			= 5,
 		PropMass		= 0.5,
-		Thrust			= 120000,	-- in kg*in/s^2 very high but only burns a brief moment, most of which is in the tube
-		FuelConsumption = 0.01,		-- in g/s/f
-		StarterPercent	= 0.1,
+		Thrust			= 100000,	-- in kg*in/s^2 very high but only burns a brief moment, most of which is in the tube
+		FuelConsumption = 0.07,		-- in g/s/f
+		StarterPercent	= 0.9,
 		MinSpeed		= 900,
 		DragCoefFlight	= 0.05,
-		DragCoef		= 0.001,
+		DragCoef		= 0.005,
 		FinMul			= 1.2,
 		PenMul			= math.sqrt(4.5),
 		ActualLength 	= 25.4,

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -77,7 +77,7 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 		PropMass		= 0.7,
 		Thrust			= 25000,	-- in kg*in/s^2
 		FuelConsumption = 0.024,	-- in g/s/f
-		StarterPercent	= 0.15,
+		StarterPercent	= 0.05,
 		MinSpeed		= 5000,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.02,
@@ -109,7 +109,7 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 		PropMass		= 0.5,
 		Thrust			= 120000,	-- in kg*in/s^2 very high but only burns a brief moment, most of which is in the tube
 		FuelConsumption = 0.01,		-- in g/s/f
-		StarterPercent	= 0.72,
+		StarterPercent	= 0.1,
 		MinSpeed		= 900,
 		DragCoefFlight	= 0.05,
 		DragCoef		= 0.001,
@@ -142,7 +142,7 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 		PropMass		= 15,
 		Thrust			= 9000, -- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
-		StarterPercent	= 0.15,
+		StarterPercent	= 0.05,
 		MinSpeed		= 10000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.01,
@@ -177,7 +177,7 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 		PropMass		= 5,
 		Thrust			= 5000, -- in kg*in/s^2
 		FuelConsumption = 1,	-- in g/s/f
-		StarterPercent	= 0.01,
+		StarterPercent	= 0.05,
 		MinSpeed		= 1,
 		DragCoef		= 0,
 		FinMul			= 0.06,


### PR DESCRIPTION
Starter percentages were adjusted for stability and balance. Larger and slower missiles have boost speeds of around 500-1000, while faster and smaller ones of around 2000-3000. Fixes certain missiles having extremely high boost speeds and clipping through the map or going backwards.