### PR TITLE
Reworked unguided missile turning, added mass to missile movement calculations, rebalanced everything

### DIFF
--- a/lua/acf/shared/missiles/aam.lua
+++ b/lua/acf/shared/missiles/aam.lua
@@ -37,6 +37,7 @@ ACF.RegisterMissile("AIM-9 AAM", "AAM", {
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.03,
 		FinMul			= 1.25,
+		TailFinMul		= 0.01,
 		CanDelayLaunch	= true,
 		ActualLength 	= 85,
 		ActualWidth		= 4.3
@@ -72,6 +73,7 @@ ACF.RegisterMissile("AIM-120 AAM", "AAM", {
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.0013,
 		FinMul			= 1.62,
+		TailFinMul		= 0.01,
 		CanDelayLaunch	= true,
 		ActualLength 	= 129.5,
 		ActualWidth		= 6.8
@@ -107,6 +109,7 @@ ACF.RegisterMissile("AIM-54 AAM", "AAM", {
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.05,
 		FinMul			= 1.2,
+		TailFinMul		= 0.01,
 		CanDelayLaunch	= true,
 		ActualLength 	= 139.5,
 		ActualWidth		= 13.5

--- a/lua/acf/shared/missiles/aam.lua
+++ b/lua/acf/shared/missiles/aam.lua
@@ -12,7 +12,7 @@ ACF.RegisterMissile("AIM-9 AAM", "AAM", {
 	Name		= "AIM-9 Sidewinder",
 	Description	= "Agile and reliable with a rather underwhelming effective range, this homing missile is the weapon of choice for dogfights.",
 	Model		= "models/missiles/aim9m.mdl",
-	Length		= 200,
+	Length		= 289,
 	Caliber		= 127,
 	Mass		= 85,
 	Year		= 1953,
@@ -27,20 +27,19 @@ ACF.RegisterMissile("AIM-9 AAM", "AAM", {
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/aim9m.mdl",
-		MaxLength		= 35,
+		MaxLength		= 289,
 		Armor			= 5,
-		PropMass		= 1,
-		Thrust			= 20000,	-- in kg*in/s^2
-		FuelConsumption = 0.025,	-- in g/s/f
+		PropMass		= 20,
+		Thrust			= 800000,	-- in kg*in/s^2
+		FuelConsumption = 0.02,		-- in g/s/f
 		StarterPercent	= 0.05,
 		MinSpeed		= 3000,
-		DragCoef		= 0.002,
-		DragCoefFlight	= 0.03,
-		FinMul			= 1.25,
-		TailFinMul		= 0.01,
+		DragCoef		= 0.015,
+		FinMul			= 0.1,
+		TailFinMul		= 0.001,
 		CanDelayLaunch	= true,
-		ActualLength 	= 85,
-		ActualWidth		= 4.3
+		ActualLength 	= 289,
+		ActualWidth		= 12.7
 	},
 })
 
@@ -48,7 +47,7 @@ ACF.RegisterMissile("AIM-120 AAM", "AAM", {
 	Name		= "AIM-120 AMRAAM",
 	Description	= "Burns hot and fast, with a good reach, but harder to lock with. This long-range missile is sure to deliver one heck of a blast upon impact.",
 	Model		= "models/missiles/aim120c.mdl",
-	Length		= 1000,
+	Length		= 370,
 	Caliber		= 180,
 	Mass		= 152,
 	Year		= 1991,
@@ -63,20 +62,19 @@ ACF.RegisterMissile("AIM-120 AAM", "AAM", {
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/aim120c.mdl",
-		MaxLength		= 50,
+		MaxLength		= 370,
 		Armor			= 5,
-		PropMass		= 2,
-		Thrust			= 24000, 	-- in kg*in/s^2
-		FuelConsumption = 0.1,		-- in g/s/f
+		PropMass		= 60,
+		Thrust			= 1200000, 	-- in kg*in/s^2
+		FuelConsumption = 0.02,		-- in g/s/f
 		StarterPercent	= 0.05,
 		MinSpeed		= 2000,
-		DragCoef		= 0.002,
-		DragCoefFlight	= 0.0013,
-		FinMul			= 1.62,
-		TailFinMul		= 0.01,
+		DragCoef		= 0.02,
+		FinMul			= 0.2,
+		TailFinMul		= 0.001,
 		CanDelayLaunch	= true,
-		ActualLength 	= 129.5,
-		ActualWidth		= 6.8
+		ActualLength 	= 370,
+		ActualWidth		= 18
 	},
 })
 
@@ -84,7 +82,7 @@ ACF.RegisterMissile("AIM-54 AAM", "AAM", {
 	Name		= "AIM-54 Phoenix",
 	Description	= "A BEEFY god-tier anti-bomber weapon, made with Jimmy Carter's repressed rage. Getting hit with one of these is a significant emotional event that is hard to avoid if you're flying high.",
 	Model		= "models/missiles/aim54.mdl",
-	Length		= 1000,
+	Length		= 400,
 	Caliber		= 380,
 	Mass		= 453,
 	Year		= 1974,
@@ -99,19 +97,18 @@ ACF.RegisterMissile("AIM-54 AAM", "AAM", {
 	ArmDelay	= 0.4,
 	Round = {
 		Model			= "models/missiles/aim54.mdl",
-		MaxLength		= 60,
+		MaxLength		= 400,
 		Armor			= 5,
-		PropMass		= 5,
-		Thrust			= 45000, 	-- in kg*in/s^2
-		FuelConsumption = 0.03,		-- in g/s/f
-		StarterPercent	= 0.002,
+		PropMass		= 360,
+		Thrust			= 3200000,	-- in kg*in/s^2
+		FuelConsumption = 0.05,		-- in g/s/f
+		StarterPercent	= 0.01,
 		MinSpeed		= 4000,
-		DragCoef		= 0.005,
-		DragCoefFlight	= 0.05,
-		FinMul			= 1.2,
-		TailFinMul		= 0.01,
+		DragCoef		= 0.1,
+		FinMul			= 0.15,
+		TailFinMul		= 0.001,
 		CanDelayLaunch	= true,
-		ActualLength 	= 139.5,
-		ActualWidth		= 13.5
+		ActualLength 	= 400,
+		ActualWidth		= 38
 	},
 })

--- a/lua/acf/shared/missiles/aam.lua
+++ b/lua/acf/shared/missiles/aam.lua
@@ -23,7 +23,7 @@ ACF.RegisterMissile("AIM-9 AAM", "AAM", {
 	Fuzes		= { Contact = true, Radio = true },
 	SeekCone	= 10,
 	ViewCone	= 30,
-	Agility		= 5,
+	Agility		= 0.25,
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/aim9m.mdl",

--- a/lua/acf/shared/missiles/arm.lua
+++ b/lua/acf/shared/missiles/arm.lua
@@ -11,7 +11,7 @@ ACF.RegisterMissile("AGM-122 ASM", "ARM", {
 	Name		= "AGM-122 Sidearm",
 	Description	= "A refurbished early-model AIM-9, for attacking ground targets.",
 	Model		= "models/missiles/aim9.mdl",
-	Length		= 205,
+	Length		= 287,
 	Caliber		= 127,
 	Mass		= 89,
 	Diameter	= 3.5 * 25.4, -- in mm
@@ -27,20 +27,19 @@ ACF.RegisterMissile("AGM-122 ASM", "ARM", {
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/aim9.mdl",
-		MaxLength		= 70,
+		MaxLength		= 287,
 		Armor			= 5,
-		PropMass		= 4,
-		Thrust			= 4500,	-- in kg*in/s^2
-		FuelConsumption = 0.3,	-- in g/s/f
-		StarterPercent	= 0.1,
-		MinSpeed		= 5000,
-		DragCoef		= 0.001,
-		DragCoefFlight	= 0.001,
-		FinMul			= 1.8,
-		TailFinMul		= 0.01,
+		PropMass		= 20,
+		Thrust			= 800000,	-- in kg*in/s^2
+		FuelConsumption = 0.02,		-- in g/s/f
+		StarterPercent	= 0.05,
+		MinSpeed		= 3000,
+		DragCoef		= 0.015,
+		FinMul			= 0.1,
+		TailFinMul		= 0.001,
 		CanDelayLaunch	= true,
-		ActualLength 	= 85,
-		ActualWidth		= 4.2
+		ActualLength 	= 287,
+		ActualWidth		= 12.7
 	},
 })
 
@@ -48,7 +47,7 @@ ACF.RegisterMissile("AGM-45 ASM", "ARM", {
 	Name		= "AGM-45 Shrike",
 	Description	= "Long range anti-SAM missile, built on the body of an AIM-7 Sparrow.",
 	Model		= "models/missiles/aim120.mdl",
-	Length		= 1000,
+	Length		= 305,
 	Caliber		= 203,
 	Mass		= 177,
 	Diameter	= 6.75 * 25.4, -- in mm
@@ -63,19 +62,18 @@ ACF.RegisterMissile("AGM-45 ASM", "ARM", {
 	ArmDelay	= 0.3,
 	Round = {
 		Model			= "models/missiles/aim120.mdl",
-		MaxLength		= 120,
+		MaxLength		= 305,
 		Armor			= 5,
-		PropMass		= 3,
-		Thrust			= 800,	-- in kg*in/s^2
-		FuelConsumption = 0.37,	-- in g/s/f
-		StarterPercent	= 0.07,
-		MinSpeed		= 4000,
-		DragCoef		= 0.001,
-		DragCoefFlight	= 0,
-		FinMul			= 12,
-		TailFinMul		= 0.01,
+		PropMass		= 40,
+		Thrust			= 1500000, 	-- in kg*in/s^2
+		FuelConsumption = 0.020,		-- in g/s/f
+		StarterPercent	= 0.05,
+		MinSpeed		= 2000,
+		DragCoef		= 0.02,
+		FinMul			= 0.2,
+		TailFinMul		= 0.001,
 		CanDelayLaunch	= true,
-		ActualLength 	= 151.5,
-		ActualWidth		= 7.1
+		ActualLength 	= 305,
+		ActualWidth		= 20.3
 	},
 })

--- a/lua/acf/shared/missiles/arm.lua
+++ b/lua/acf/shared/missiles/arm.lua
@@ -37,6 +37,7 @@ ACF.RegisterMissile("AGM-122 ASM", "ARM", {
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.001,
 		FinMul			= 1.8,
+		TailFinMul		= 0.01,
 		CanDelayLaunch	= true,
 		ActualLength 	= 85,
 		ActualWidth		= 4.2
@@ -72,6 +73,7 @@ ACF.RegisterMissile("AGM-45 ASM", "ARM", {
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0,
 		FinMul			= 12,
+		TailFinMul		= 0.01,
 		CanDelayLaunch	= true,
 		ActualLength 	= 151.5,
 		ActualWidth		= 7.1

--- a/lua/acf/shared/missiles/arty.lua
+++ b/lua/acf/shared/missiles/arty.lua
@@ -28,7 +28,7 @@ ACF.RegisterMissile("Type 63 RA", "ARTY", {
 		Model			= "models/missiles/glatgm/mgm51.mdl",
 		MaxLength		= 80,
 		Armor			= 5,
-		PropMass		= 5,
+		PropMass		= 3.2,
 		Thrust			= 240000,	-- in kg*in/s^2
 		FuelConsumption = 0.06, 	-- in g/s/f
 		StarterPercent	= 0.05,
@@ -63,14 +63,14 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 		MaxLength		= 287,
 		Armor			= 5,
 		PropMass		= 12,
-		Thrust			= 1600000, -- in kg*in/s^2
+		Thrust			= 800000, -- in kg*in/s^2
 		FuelConsumption = 0.012,	-- in g/s/f
 		StarterPercent	= 0.05,
 		MinSpeed		= 300,
 		DragCoef		= 0.02,
 		FinMul			= 0.06,
 		TailFinMul		= 2,
-		PenMul			= math.sqrt(1.1),
+		PenMul			= math.sqrt(0.5),
 		ActualLength 	= 287,
 		ActualWidth		= 12.2
 	},
@@ -104,7 +104,7 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 		DragCoef		= 0.02,
 		FinMul			= 0.12,
 		TailFinMul		= 10,
-		PenMul			= math.sqrt(1.1),
+		PenMul			= math.sqrt(0.5),
 		ActualLength 	= 370,
 		ActualWidth		= 18
 	},

--- a/lua/acf/shared/missiles/arty.lua
+++ b/lua/acf/shared/missiles/arty.lua
@@ -35,7 +35,8 @@ ACF.RegisterMissile("Type 63 RA", "ARTY", {
 		MinSpeed		= 200,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.001,
-		FinMul			= 1.2,
+		FinMul			= 0,
+		TailFinMul		= 2,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 50,
 		ActualWidth		= 7.2
@@ -69,7 +70,8 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 		MinSpeed		= 300,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.010,
-		FinMul			= 1.8,
+		FinMul			= 1,
+		TailFinMul		= 3,
 		PenMul			= math.sqrt(1.1),
 		ActualLength 	= 86.5,
 		ActualWidth		= 5.5
@@ -97,13 +99,14 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 		MaxLength		= 115,
 		Armor			= 5,
 		PropMass		= 4.0,
-		Thrust			= 850,	-- in kg*in/s^2
+		Thrust			= 1850,	-- in kg*in/s^2
 		FuelConsumption = 0.4,	-- in g/s/f
 		StarterPercent	= 0.05,
 		MinSpeed		= 300,
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.009,
-		FinMul			= 3,
+		FinMul			= 1.2,
+		TailFinMul		= 5,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 151.5,
 		ActualWidth		= 7.1

--- a/lua/acf/shared/missiles/arty.lua
+++ b/lua/acf/shared/missiles/arty.lua
@@ -26,20 +26,19 @@ ACF.RegisterMissile("Type 63 RA", "ARTY", {
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/glatgm/mgm51.mdl",
-		MaxLength		= 50,
+		MaxLength		= 80,
 		Armor			= 5,
-		PropMass		= 0.7,
-		Thrust			= 2400, -- in kg*in/s^2
-		FuelConsumption = 0.16, -- in g/s/f
+		PropMass		= 5,
+		Thrust			= 240000,	-- in kg*in/s^2
+		FuelConsumption = 0.06, 	-- in g/s/f
 		StarterPercent	= 0.05,
 		MinSpeed		= 200,
-		DragCoef		= 0.002,
-		DragCoefFlight	= 0.001,
+		DragCoef		= 0.005,
 		FinMul			= 0,
 		TailFinMul		= 2,
 		PenMul			= math.sqrt(2),
-		ActualLength 	= 50,
-		ActualWidth		= 7.2
+		ActualLength 	= 80,
+		ActualWidth		= 10.7
 	},
 })
 
@@ -49,7 +48,7 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 	Model		= "models/missiles/9m31.mdl",
 	Caliber		= 122,
 	Mass		= 56,
-	Length		= 320,
+	Length		= 287,
 	Diameter	= 4.6 * 25.4, -- in mm
 	Year		= 1980,
 	ReloadTime	= 20,
@@ -61,20 +60,19 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 	ArmDelay	= 0.4,
 	Round = {
 		Model		= "models/missiles/9m31.mdl",
-		MaxLength		= 140,
+		MaxLength		= 287,
 		Armor			= 5,
-		PropMass		= 1.2,
-		Thrust			= 1300, -- in kg*in/s^2
-		FuelConsumption = 0.1,	-- in g/s/f
+		PropMass		= 12,
+		Thrust			= 1600000, -- in kg*in/s^2
+		FuelConsumption = 0.012,	-- in g/s/f
 		StarterPercent	= 0.05,
 		MinSpeed		= 300,
-		DragCoef		= 0.002,
-		DragCoefFlight	= 0.010,
-		FinMul			= 1,
-		TailFinMul		= 3,
+		DragCoef		= 0.02,
+		FinMul			= 0.06,
+		TailFinMul		= 2,
 		PenMul			= math.sqrt(1.1),
-		ActualLength 	= 86.5,
-		ActualWidth		= 5.5
+		ActualLength 	= 287,
+		ActualWidth		= 12.2
 	},
 })
 
@@ -84,7 +82,7 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 	Model		= "models/missiles/aim120.mdl",
 	Caliber		= 180,
 	Mass		= 152,
-	Length		= 420,
+	Length		= 370,
 	Diameter	= 6.75 * 25.4, -- in mm
 	Year		= 1983,
 	ReloadTime	= 30,
@@ -96,19 +94,18 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 	ArmDelay	= 0.6,
 	Round = {
 		Model		= "models/missiles/aim120.mdl",
-		MaxLength		= 115,
+		MaxLength		= 370,
 		Armor			= 5,
-		PropMass		= 4.0,
-		Thrust			= 1850,	-- in kg*in/s^2
-		FuelConsumption = 0.4,	-- in g/s/f
+		PropMass		= 40,
+		Thrust			= 2400000, -- in kg*in/s^2
+		FuelConsumption = 0.022,	-- in g/s/f
 		StarterPercent	= 0.05,
 		MinSpeed		= 300,
-		DragCoef		= 0.002,
-		DragCoefFlight	= 0.009,
-		FinMul			= 1.2,
-		TailFinMul		= 5,
-		PenMul			= math.sqrt(2),
-		ActualLength 	= 151.5,
-		ActualWidth		= 7.1
+		DragCoef		= 0.02,
+		FinMul			= 0.12,
+		TailFinMul		= 10,
+		PenMul			= math.sqrt(1.1),
+		ActualLength 	= 370,
+		ActualWidth		= 18
 	},
 })

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -36,6 +36,7 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.1,
 		FinMul			= 6,
+		TailFinMul		= 0.01,
 		PenMul			= math.sqrt(5.39),
 		ActualLength 	= 34.5,
 		ActualWidth		= 5.2
@@ -69,6 +70,7 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 		DragCoef		= 0.005,
 		DragCoefFlight	= 0.05,
 		FinMul			= 3,
+		TailFinMul		= 0.01,
 		PenMul			= math.sqrt(3.97),
 		ActualLength 	= 59,
 		ActualWidth		= 5.9
@@ -117,6 +119,7 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.05,
 		FinMul			= 3,
+		TailFinMul		= 0.01,
 		PenMul			= math.sqrt(4.175),
 		ActualLength 	= 64.7,
 		ActualWidth		= 7.9
@@ -153,6 +156,7 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.04,
 		FinMul			= 3,
+		TailFinMul		= 0.01,
 		PenMul			= math.sqrt(1.454),
 		ActualLength 	= 68.5,
 		ActualWidth		= 5.2
@@ -198,6 +202,7 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.02,
 		FinMul			= 3,
+		TailFinMul		= 0.01,
 		PenMul			= math.sqrt(4.2),
 		ActualLength 	= 55.3,
 		ActualWidth		= 7
@@ -232,6 +237,7 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 		DragCoef		= 0.01,
 		DragCoefFlight	= 0.04,
 		FinMul			= 6,
+		TailFinMul		= 0.01,
 		PenMul			= math.sqrt(3.025),
 		ActualLength 	= 45.5,
 		ActualWidth		= 5.5

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -12,7 +12,7 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 	Name		= "9M14 Malyutka",
 	Description	= "The 9M14 Malyutka (AT-3 Sagger) is a short-range wire-guided anti-tank missile.",
 	Model		= "models/missiles/at3.mdl",
-	Length		= 43,
+	Length		= 86,
 	Caliber		= 125,
 	Mass		= 11,
 	Diameter	= 4.2 * 25.4,
@@ -26,20 +26,19 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/at3.mdl",
-		MaxLength		= 35,
+		MaxLength		= 86,
 		Armor			= 5,
-		PropMass		= 0.2,
-		Thrust			= 8000, 	-- in kg*in/s^2
-		FuelConsumption = 0.0025,	-- in g/s/f
-		StarterPercent	= 0.005,
+		PropMass		= 5,
+		Thrust			= 11000,	-- in kg*in/s^2
+		FuelConsumption = 0.05,		-- in g/s/f
+		StarterPercent	= 0.25,
 		MinSpeed		= 1500,
-		DragCoef		= 0.005,
-		DragCoefFlight	= 0.1,
-		FinMul			= 6,
+		DragCoef		= 0.04,
+		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(5.39),
-		ActualLength 	= 34.5,
-		ActualWidth		= 5.2
+		PenMul			= math.sqrt(4.4),
+		ActualLength 	= 86,
+		ActualWidth		= 12.5
 	},
 })
 
@@ -47,7 +46,7 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 	Name		= "BGM-71E TOW",
 	Description	= "The BGM-71E TOW is a medium-range wire guided anti-tank missile.",
 	Model		= "models/missiles/bgm_71e.mdl",
-	Length		= 46,
+	Length		= 117,	-- Length not counting the probe
 	Caliber		= 152,
 	Mass		= 23,
 	Year		= 1970,
@@ -60,20 +59,19 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/bgm_71e.mdl",
-		MaxLength		= 64,
+		MaxLength		= 117,
 		Armor			= 5,
-		PropMass		= 0.2,
-		Thrust			= 13000, -- in kg*in/s^2
-		FuelConsumption = 0.0025,	-- in g/s/f
-		StarterPercent	= 0.003,
+		PropMass		= 10,
+		Thrust			= 250000,	-- in kg*in/s^2
+		FuelConsumption = 0.045,	-- in g/s/f
+		StarterPercent	= 0.2,
 		MinSpeed		= 2000,
 		DragCoef		= 0.005,
-		DragCoefFlight	= 0.05,
-		FinMul			= 3,
+		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(3.97),
-		ActualLength 	= 59,
-		ActualWidth		= 5.9
+		PenMul			= math.sqrt(6.2),
+		ActualLength 	= 117,
+		ActualWidth		= 15.2
 	},
 })
 
@@ -81,7 +79,7 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 	Name		= "AGM-114 Hellfire",
 	Description	= "The AGM-114 Hellfire is a heavy air-to-surface missile, used often by American aircraft.",
 	Model		= "models/missiles/agm_114.mdl",
-	Length		= 66,
+	Length		= 160,
 	Caliber		= 180,
 	Mass		= 49,
 	Diameter	= 6.5 * 25.4, -- in mm
@@ -109,20 +107,19 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 	},
 	Round = {
 		Model			= "models/missiles/agm_114.mdl",
-		MaxLength		= 67,
+		MaxLength		= 160,
 		Armor			= 5,
-		PropMass		= 0.25,
-		Thrust			= 18000, 	-- in kg*in/s^2
-		FuelConsumption = 0.0045,	-- in g/s/f
-		StarterPercent	= 0.005,
+		PropMass		= 20,
+		Thrust			= 600000,	-- in kg*in/s^2
+		FuelConsumption = 0.05,		-- in g/s/f
+		StarterPercent	= 0.02,
 		MinSpeed		= 4000,
-		DragCoef		= 0.001,
-		DragCoefFlight	= 0.05,
-		FinMul			= 3,
+		DragCoef		= 0.005,
+		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(4.175),
-		ActualLength 	= 64.7,
-		ActualWidth		= 7.9
+		PenMul			= math.sqrt(4.8),
+		ActualLength 	= 160,
+		ActualWidth		= 18
 	},
 })
 
@@ -130,7 +127,7 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 	Name		= "9M120 Ataka",
 	Description	= "The 9M120 Ataka (AT-9 Spiral-2) is a heavy air-to-surface missile, used often by soviet helicopters and ground vehicles.",
 	Model		= "models/missiles/9m120.mdl",
-	Length		= 85,
+	Length		= 183,
 	Caliber		= 130,
 	Mass		= 50,
 	Diameter	= 10.9 * 25.4, -- in mm
@@ -146,20 +143,19 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 	Round = {
 		Model			= "models/missiles/9m120.mdl",
 		RackModel		= "models/missiles/9m120_rk1.mdl",
-		MaxLength		= 120,
+		MaxLength		= 183,
 		Armor			= 5,
-		PropMass		= 0.11,
-		Thrust			= 20000, -- in kg*in/s^2
-		FuelConsumption = 0.015,	-- in g/s/f
-		StarterPercent	= 0.04,
-		MinSpeed		= 800,
-		DragCoef		= 0.001,
-		DragCoefFlight	= 0.04,
-		FinMul			= 3,
+		PropMass		= 12,
+		Thrust			= 600000,	-- in kg*in/s^2
+		FuelConsumption = 0.045,		-- in g/s/f
+		StarterPercent	= 0.02,
+		MinSpeed		= 4000,
+		DragCoef		= 0.005,
+		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(1.454),
-		ActualLength 	= 68.5,
-		ActualWidth		= 5.2
+		PenMul			= math.sqrt(4.5),
+		ActualLength 	= 183,
+		ActualWidth		= 13
 	},
 })
 
@@ -167,7 +163,7 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 	Name		= "9M133 Kornet",
 	Description	= "The 9M133 Kornet (AT-14 Spriggan) is an extremely powerful antitank missile.",
 	Model		= "models/kali/weapons/kornet/parts/9m133 kornet missile.mdl",
-	Length		= 80,
+	Length		= 120,
 	Caliber		= 152,
 	Mass		= 27,
 	Year		= 1994,
@@ -192,20 +188,19 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 	},
 	Round = {
 		Model			= "models/kali/weapons/kornet/parts/9m133 kornet missile.mdl",
-		MaxLength		= 70,
+		MaxLength		= 120,
 		Armor			= 5,
-		PropMass		= 0.1,
-		Thrust			= 25000, 	-- in kg*in/s^2
-		FuelConsumption = 0.001,	-- in g/s/f
-		StarterPercent	= 0.002,
-		MinSpeed		= 8000,
-		DragCoef		= 0.002,
-		DragCoefFlight	= 0.02,
-		FinMul			= 3,
+		PropMass		= 8,
+		Thrust			= 230000,	-- in kg*in/s^2
+		FuelConsumption = 0.035,	-- in g/s/f
+		StarterPercent	= 0.1,
+		MinSpeed		= 2000,
+		DragCoef		= 0.005,
+		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(4.2),
-		ActualLength 	= 55.3,
-		ActualWidth		= 7
+		PenMul			= math.sqrt(5.8),
+		ActualLength 	= 120,
+		ActualWidth		= 15.2
 	},
 })
 
@@ -213,7 +208,7 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 	Name		= "9M17 Fleyta",
 	Description	= "The 9M17 Fleyta (AT-2 Sagger) is a powerful radio command medium-range antitank missile, intended for use on helicopters and anti tank vehicles. It has a more powerful warhead and longer range than the AT-3 at the cost of weight and agility.",
 	Model		= "models/missiles/at2.mdl",
-	Length		= 55,
+	Length		= 116,
 	Caliber		= 148,
 	Mass		= 27,
 	Year		= 1969,
@@ -227,19 +222,18 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/at2.mdl",
-		MaxLength		= 60,
+		MaxLength		= 116,
 		Armor			= 5,
-		PropMass		= 0.07,
-		Thrust			= 6000, 	-- in kg*in/s^2
-		FuelConsumption = 0.0015,	-- in g/s/f
-		StarterPercent	= 0.004,
-		MinSpeed		= 500,
-		DragCoef		= 0.01,
-		DragCoefFlight	= 0.04,
-		FinMul			= 6,
+		PropMass		= 8,
+		Thrust			= 40000,	-- in kg*in/s^2
+		FuelConsumption = 0.035,	-- in g/s/f
+		StarterPercent	= 0.25,
+		MinSpeed		= 1500,
+		DragCoef		= 0.06,
+		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(3.025),
-		ActualLength 	= 45.5,
-		ActualWidth		= 5.5
+		PenMul			= math.sqrt(3.6),
+		ActualLength 	= 116,
+		ActualWidth		= 14.8
 	},
 })

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -28,7 +28,7 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 		Model			= "models/missiles/at3.mdl",
 		MaxLength		= 86,
 		Armor			= 5,
-		PropMass		= 5,
+		PropMass		= 4,
 		Thrust			= 11000,	-- in kg*in/s^2
 		FuelConsumption = 0.05,		-- in g/s/f
 		StarterPercent	= 0.25,
@@ -36,7 +36,7 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 		DragCoef		= 0.04,
 		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(4.4),
+		PenMul			= math.sqrt(2),
 		ActualLength 	= 86,
 		ActualWidth		= 12.5
 	},
@@ -61,7 +61,7 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 		Model			= "models/missiles/bgm_71e.mdl",
 		MaxLength		= 117,
 		Armor			= 5,
-		PropMass		= 10,
+		PropMass		= 9,
 		Thrust			= 250000,	-- in kg*in/s^2
 		FuelConsumption = 0.045,	-- in g/s/f
 		StarterPercent	= 0.2,
@@ -69,7 +69,7 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 		DragCoef		= 0.005,
 		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(6.2),
+		PenMul			= math.sqrt(3),
 		ActualLength 	= 117,
 		ActualWidth		= 15.2
 	},
@@ -109,7 +109,7 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 		Model			= "models/missiles/agm_114.mdl",
 		MaxLength		= 160,
 		Armor			= 5,
-		PropMass		= 20,
+		PropMass		= 16,
 		Thrust			= 600000,	-- in kg*in/s^2
 		FuelConsumption = 0.05,		-- in g/s/f
 		StarterPercent	= 0.02,
@@ -117,7 +117,7 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 		DragCoef		= 0.005,
 		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(4.8),
+		PenMul			= math.sqrt(2),
 		ActualLength 	= 160,
 		ActualWidth		= 18
 	},
@@ -145,7 +145,7 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 		RackModel		= "models/missiles/9m120_rk1.mdl",
 		MaxLength		= 183,
 		Armor			= 5,
-		PropMass		= 12,
+		PropMass		= 9,
 		Thrust			= 600000,	-- in kg*in/s^2
 		FuelConsumption = 0.045,		-- in g/s/f
 		StarterPercent	= 0.02,
@@ -153,7 +153,7 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 		DragCoef		= 0.005,
 		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(4.5),
+		PenMul			= math.sqrt(2),
 		ActualLength 	= 183,
 		ActualWidth		= 13
 	},
@@ -198,7 +198,7 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		DragCoef		= 0.005,
 		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(5.8),
+		PenMul			= math.sqrt(3.5),
 		ActualLength 	= 120,
 		ActualWidth		= 15.2
 	},
@@ -232,7 +232,7 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 		DragCoef		= 0.06,
 		FinMul			= 0.1,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(3.6),
+		PenMul			= math.sqrt(2),
 		ActualLength 	= 116,
 		ActualWidth		= 14.8
 	},

--- a/lua/acf/shared/missiles/bomb.lua
+++ b/lua/acf/shared/missiles/bomb.lua
@@ -35,6 +35,7 @@ ACF.RegisterMissile("50kgBOMB", "BOMB", {
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
 		FinMul			= 0.48,
+		TailFinMul		= 10,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 37,
 		ActualWidth		= 9.2
@@ -68,6 +69,7 @@ ACF.RegisterMissile("100kgBOMB", "BOMB", {
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
 		FinMul			= 0.42,
+		TailFinMul		= 20,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 44,
 		ActualWidth		= 12
@@ -101,6 +103,7 @@ ACF.RegisterMissile("250kgBOMB", "BOMB", {
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
 		FinMul			= 0.3,
+		TailFinMul		= 20,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 83,
 		ActualWidth		= 14.5
@@ -134,6 +137,7 @@ ACF.RegisterMissile("500kgBOMB", "BOMB", {
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
 		FinMul			= 0.24,
+		TailFinMul		= 30,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 85,
 		ActualWidth		= 17.5
@@ -167,6 +171,7 @@ ACF.RegisterMissile("1000kgBOMB", "BOMB", {
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
 		FinMul			= 0.24,
+		TailFinMul		= 40,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 90.5,
 		ActualWidth		= 22.7

--- a/lua/acf/shared/missiles/bomb.lua
+++ b/lua/acf/shared/missiles/bomb.lua
@@ -36,7 +36,7 @@ ACF.RegisterMissile("50kgBOMB", "BOMB", {
 		DragCoef		= 0.01,
 		FinMul			= 0.001,
 		TailFinMul		= 0.1,
-		PenMul			= math.sqrt(0.6),
+		PenMul			= math.sqrt(0.3),
 		ActualLength 	= 50,
 		ActualWidth		= 5
 	},
@@ -70,7 +70,7 @@ ACF.RegisterMissile("100kgBOMB", "BOMB", {
 		DragCoef		= 0.02,
 		FinMul			= 0.002,
 		TailFinMul		= 2,
-		PenMul			= math.sqrt(0.6),
+		PenMul			= math.sqrt(0.3),
 		ActualLength 	= 100,
 		ActualWidth		= 10
 	},
@@ -94,7 +94,7 @@ ACF.RegisterMissile("250kgBOMB", "BOMB", {
 	ArmDelay	= 1,
 	Round = {
 		Model			= "models/bombs/fab250.mdl",
-		MaxLength		= 250,
+		MaxLength		= 200,
 		Armor			= 10,
 		PropMass		= 0,
 		Thrust			= 1, 	-- in kg*in/s^2
@@ -104,8 +104,8 @@ ACF.RegisterMissile("250kgBOMB", "BOMB", {
 		DragCoef		= 0.03,
 		FinMul			= 0.003,
 		TailFinMul		= 4,
-		PenMul			= math.sqrt(0.6),
-		ActualLength 	= 250,
+		PenMul			= math.sqrt(0.3),
+		ActualLength 	= 200,
 		ActualWidth		= 12.5
 	},
 })
@@ -128,7 +128,7 @@ ACF.RegisterMissile("500kgBOMB", "BOMB", {
 	ArmDelay	= 2,
 	Round = {
 		Model			= "models/bombs/fab500.mdl",
-		MaxLength		= 200,
+		MaxLength		= 250,
 		Armor			= 10,
 		PropMass		= 0,
 		Thrust			= 1, 	-- in kg*in/s^2
@@ -138,8 +138,8 @@ ACF.RegisterMissile("500kgBOMB", "BOMB", {
 		DragCoef		= 0.05,
 		FinMul			= 0.005,
 		TailFinMul		= 40,
-		PenMul			= math.sqrt(0.6),
-		ActualLength 	= 200,
+		PenMul			= math.sqrt(0.3),
+		ActualLength 	= 250,
 		ActualWidth		= 30
 	},
 })
@@ -148,7 +148,7 @@ ACF.RegisterMissile("1000kgBOMB", "BOMB", {
 	Name		= "1000kg Free Falling Bomb",
 	Description	= "A 2000lb bomb. As close to a nuke as you can get in ACF, this munition will turn everything it touches to ashes. Handle with care.",
 	Model		= "models/bombs/an_m66.mdl",
-	Length		= 400,
+	Length		= 375,
 	Caliber		= 300,
 	Mass		= 1000,
 	Year		= 1945,
@@ -172,7 +172,7 @@ ACF.RegisterMissile("1000kgBOMB", "BOMB", {
 		DragCoef		= 0.1,
 		FinMul			= 0.01,
 		TailFinMul		= 60,
-		PenMul			= math.sqrt(0.6),
+		PenMul			= math.sqrt(0.3),
 		ActualLength 	= 375,
 		ActualWidth		= 30
 	},

--- a/lua/acf/shared/missiles/bomb.lua
+++ b/lua/acf/shared/missiles/bomb.lua
@@ -12,7 +12,7 @@ ACF.RegisterMissile("50kgBOMB", "BOMB", {
 	Name		= "50kg Free Falling Bomb",
 	Description	= "Old WW2 100lb bomb, most effective vs exposed infantry and light trucks.",
 	Model		= "models/bombs/fab50.mdl",
-	Length		= 5,
+	Length		= 50,
 	Caliber		= 50,
 	Mass		= 50,
 	Year		= 1936,
@@ -33,12 +33,12 @@ ACF.RegisterMissile("50kgBOMB", "BOMB", {
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.01,
 		MinSpeed		= 1,
-		DragCoef		= 0.002,
-		FinMul			= 0.48,
-		TailFinMul		= 10,
+		DragCoef		= 0.01,
+		FinMul			= 0.001,
+		TailFinMul		= 0.1,
 		PenMul			= math.sqrt(0.6),
-		ActualLength 	= 37,
-		ActualWidth		= 9.2
+		ActualLength 	= 50,
+		ActualWidth		= 5
 	},
 })
 
@@ -46,7 +46,7 @@ ACF.RegisterMissile("100kgBOMB", "BOMB", {
 	Name		= "100kg Free Falling Bomb",
 	Description	= "An old 250lb WW2 bomb, as used by Soviet bombers to destroy enemies of the Motherland.",
 	Model		= "models/bombs/fab100.mdl",
-	Length		= 50,
+	Length		= 100,
 	Caliber		= 100,
 	Mass		= 100,
 	Year		= 1939,
@@ -67,12 +67,12 @@ ACF.RegisterMissile("100kgBOMB", "BOMB", {
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
-		DragCoef		= 0.002,
-		FinMul			= 0.42,
-		TailFinMul		= 20,
+		DragCoef		= 0.02,
+		FinMul			= 0.002,
+		TailFinMul		= 2,
 		PenMul			= math.sqrt(0.6),
-		ActualLength 	= 44,
-		ActualWidth		= 12
+		ActualLength 	= 100,
+		ActualWidth		= 10
 	},
 })
 
@@ -80,7 +80,7 @@ ACF.RegisterMissile("250kgBOMB", "BOMB", {
 	Name		= "250kg Free Falling Bomb",
 	Description	= "A heavy 500lb bomb, widely used as a tank buster on various WW2 aircraft.",
 	Model		= "models/bombs/fab250.mdl",
-	Length		= 5000,
+	Length		= 200,
 	Caliber		= 125,
 	Mass		= 250,
 	Year		= 1941,
@@ -101,12 +101,12 @@ ACF.RegisterMissile("250kgBOMB", "BOMB", {
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
-		DragCoef		= 0.002,
-		FinMul			= 0.3,
-		TailFinMul		= 20,
+		DragCoef		= 0.03,
+		FinMul			= 0.003,
+		TailFinMul		= 4,
 		PenMul			= math.sqrt(0.6),
-		ActualLength 	= 83,
-		ActualWidth		= 14.5
+		ActualLength 	= 250,
+		ActualWidth		= 12.5
 	},
 })
 
@@ -114,7 +114,7 @@ ACF.RegisterMissile("500kgBOMB", "BOMB", {
 	Name		= "500kg Free Falling Bomb",
 	Description	= "A 1000lb bomb, as found in the heavy bombers of late WW2. Best used against fortifications or immobile targets.",
 	Model		= "models/bombs/fab500.mdl",
-	Length		= 15000,
+	Length		= 250,
 	Caliber		= 300,
 	Mass		= 500,
 	Year		= 1943,
@@ -135,12 +135,12 @@ ACF.RegisterMissile("500kgBOMB", "BOMB", {
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
-		DragCoef		= 0.002,
-		FinMul			= 0.24,
-		TailFinMul		= 30,
+		DragCoef		= 0.05,
+		FinMul			= 0.005,
+		TailFinMul		= 40,
 		PenMul			= math.sqrt(0.6),
-		ActualLength 	= 85,
-		ActualWidth		= 17.5
+		ActualLength 	= 200,
+		ActualWidth		= 30
 	},
 })
 
@@ -148,7 +148,7 @@ ACF.RegisterMissile("1000kgBOMB", "BOMB", {
 	Name		= "1000kg Free Falling Bomb",
 	Description	= "A 2000lb bomb. As close to a nuke as you can get in ACF, this munition will turn everything it touches to ashes. Handle with care.",
 	Model		= "models/bombs/an_m66.mdl",
-	Length		= 30000,
+	Length		= 400,
 	Caliber		= 300,
 	Mass		= 1000,
 	Year		= 1945,
@@ -169,11 +169,11 @@ ACF.RegisterMissile("1000kgBOMB", "BOMB", {
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
-		DragCoef		= 0.002,
-		FinMul			= 0.24,
-		TailFinMul		= 40,
+		DragCoef		= 0.1,
+		FinMul			= 0.01,
+		TailFinMul		= 60,
 		PenMul			= math.sqrt(0.6),
-		ActualLength 	= 90.5,
-		ActualWidth		= 22.7
+		ActualLength 	= 375,
+		ActualWidth		= 30
 	},
 })

--- a/lua/acf/shared/missiles/ffar.lua
+++ b/lua/acf/shared/missiles/ffar.lua
@@ -14,7 +14,7 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 	Model		= "models/missiles/ffar_40mm.mdl",
 	Caliber		= 40,
 	Mass		= 4,
-	Length		= 2,
+	Length		= 60,
 	Year		= 1960,
 	ReloadTime	= 7.5,
 	Racks		= { ["40mm7xPOD"] = true },
@@ -24,20 +24,19 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 	Round = {
 		Model			= "models/missiles/ffar_40mm.mdl",
 		RackModel		= "models/missiles/ffar_40mm_closed.mdl",
-		MaxLength		= 25,
+		MaxLength		= 60,
 		Armor			= 5,
-		PropMass		= 0.2,
-		Thrust			= 10000, 	-- in kg*in/s^2
-		FuelConsumption = 0.012,	-- in g/s/f
+		PropMass		= 0.3,
+		Thrust			= 150000,	-- in kg*in/s^2
+		FuelConsumption = 0.015,	-- in g/s/f
 		StarterPercent	= 0.1,
 		MinSpeed		= 5000,
 		DragCoef		= 0.001,
-		DragCoefFlight	= 0.02,
-		FinMul			= 0.18,
-		TailFinMul		= 0.05,
+		FinMul			= 0.01,
+		TailFinMul		= 0.005,
 		PenMul			= math.sqrt(4),
-		ActualLength 	= 26.5,
-		ActualWidth		= 1.6
+		ActualLength 	= 60,
+		ActualWidth		= 4
 	},
 })
 
@@ -47,7 +46,7 @@ ACF.RegisterMissile("70mmFFAR", "FFAR", {
 	Model		= "models/missiles/ffar_70mm.mdl",
 	Caliber		= 70,
 	Mass		= 6,
-	Length		= 15,
+	Length		= 106,
 	Year		= 1960,
 	ReloadTime	= 10,
 	Racks		= { ["70mm7xPOD"] = true },
@@ -58,20 +57,19 @@ ACF.RegisterMissile("70mmFFAR", "FFAR", {
 	Round = {
 		Model			= "models/missiles/ffar_70mm.mdl",
 		RackModel		= "models/missiles/ffar_70mm_closed.mdl",
-		MaxLength		= 25,
+		MaxLength		= 106,
 		Armor			= 5,
-		PropMass		= 0.7,
-		Thrust			= 15000,	-- in kg*in/s^2
-		FuelConsumption = 0.02,		-- in g/s/f
-		StarterPercent	= 0.05,
-		MinSpeed		= 4000,
-		DragCoef		= 0.001,
-		DragCoefFlight	= 0.02,
-		FinMul			= 0.9,
-		TailFinMul		= 0.02,
-		PenMul			= math.sqrt(6),
-		ActualLength 	= 46,
-		ActualWidth		= 2.6
+		PropMass		= 1.5,
+		Thrust			= 850000,	-- in kg*in/s^2
+		FuelConsumption = 0.010,	-- in g/s/f
+		StarterPercent	= 0.1,
+		MinSpeed		= 5000,
+		DragCoef		= 0.002,
+		FinMul			= 0.01,
+		TailFinMul		= 0.005,
+		PenMul			= math.sqrt(2.3),
+		ActualLength 	= 106,
+		ActualWidth		= 7
 	},
 })
 
@@ -81,7 +79,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 	Model		= "models/ghosteh/zuni.mdl",
 	Caliber		= 127,
 	Mass		= 45,
-	Length		= 80,
+	Length		= 200,
 	Year		= 1957,
 	ReloadTime	= 15,
 	Racks		= { ["127mm4xPOD"] = true },
@@ -92,19 +90,18 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 	Round = {
 		Model			= "models/ghosteh/zuni.mdl",
 		RackModel		= "models/ghosteh/zuni_folded.mdl",
-		MaxLength		= 60,
+		MaxLength		= 200,
 		Armor			= 5,
-		PropMass		= 0.7,
-		Thrust			= 18000, 	-- in kg*in/s^2
-		FuelConsumption = 0.03,		-- in g/s/f
-		StarterPercent	= 0.05,
-		MinSpeed		= 6000,
-		DragCoef		= 0.001,
-		DragCoefFlight	= 0.02,
-		FinMul			= 0.9,
+		PropMass		= 16,
+		Thrust			= 800000,	-- in kg*in/s^2
+		FuelConsumption = 0.032,	-- in g/s/f
+		StarterPercent	= 0.1,
+		MinSpeed		= 5000,
+		DragCoef		= 0.004,
+		FinMul			= 0.005,
 		TailFinMul		= 0.04,
-		PenMul			= math.sqrt(2),
-		ActualLength 	= 118,
-		ActualWidth		= 4.8
+		PenMul			= math.sqrt(3.5),
+		ActualLength 	= 200,
+		ActualWidth		= 12.7
 	},
 })

--- a/lua/acf/shared/missiles/ffar.lua
+++ b/lua/acf/shared/missiles/ffar.lua
@@ -34,7 +34,7 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 		DragCoef		= 0.001,
 		FinMul			= 0.01,
 		TailFinMul		= 0.005,
-		PenMul			= math.sqrt(4),
+		PenMul			= math.sqrt(2),
 		ActualLength 	= 60,
 		ActualWidth		= 4
 	},
@@ -67,7 +67,7 @@ ACF.RegisterMissile("70mmFFAR", "FFAR", {
 		DragCoef		= 0.002,
 		FinMul			= 0.01,
 		TailFinMul		= 0.005,
-		PenMul			= math.sqrt(2.3),
+		PenMul			= math.sqrt(1),
 		ActualLength 	= 106,
 		ActualWidth		= 7
 	},
@@ -92,7 +92,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		RackModel		= "models/ghosteh/zuni_folded.mdl",
 		MaxLength		= 200,
 		Armor			= 5,
-		PropMass		= 16,
+		PropMass		= 8,
 		Thrust			= 800000,	-- in kg*in/s^2
 		FuelConsumption = 0.032,	-- in g/s/f
 		StarterPercent	= 0.1,
@@ -100,7 +100,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		DragCoef		= 0.004,
 		FinMul			= 0.005,
 		TailFinMul		= 0.04,
-		PenMul			= math.sqrt(3.5),
+		PenMul			= math.sqrt(1),
 		ActualLength 	= 200,
 		ActualWidth		= 12.7
 	},

--- a/lua/acf/shared/missiles/ffar.lua
+++ b/lua/acf/shared/missiles/ffar.lua
@@ -34,6 +34,7 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,
 		FinMul			= 0.18,
+		TailFinMul		= 0.05,
 		PenMul			= math.sqrt(4),
 		ActualLength 	= 26.5,
 		ActualWidth		= 1.6
@@ -67,6 +68,7 @@ ACF.RegisterMissile("70mmFFAR", "FFAR", {
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,
 		FinMul			= 0.9,
+		TailFinMul		= 0.02,
 		PenMul			= math.sqrt(6),
 		ActualLength 	= 46,
 		ActualWidth		= 2.6
@@ -100,6 +102,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.02,
 		FinMul			= 0.9,
+		TailFinMul		= 0.04,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 118,
 		ActualWidth		= 4.8

--- a/lua/acf/shared/missiles/gbomb.lua
+++ b/lua/acf/shared/missiles/gbomb.lua
@@ -31,7 +31,8 @@ ACF.RegisterMissile("100kgGBOMB", "GBOMB", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
 		DragCoef		= 0.0001,
-		FinMul			= 3,
+		FinMul			= 5,
+		TailFinMul		= 3,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 50,
 		ActualWidth		= 11.4
@@ -62,7 +63,8 @@ ACF.RegisterMissile("250kgGBOMB", "GBOMB", {
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
 		DragCoef		= 0.001,
-		FinMul			= 3,
+		FinMul			= 5,
+		TailFinMul		= 3,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 67,
 		ActualWidth		= 15

--- a/lua/acf/shared/missiles/gbomb.lua
+++ b/lua/acf/shared/missiles/gbomb.lua
@@ -11,7 +11,7 @@ ACF.RegisterMissile("100kgGBOMB", "GBOMB", {
 	Name		= "100kg Glide Bomb",
 	Description	= "A 250-pound bomb, fitted with fins for a longer reach. Well suited to dive bombing, but bulkier and heavier from its fins.",
 	Model		= "models/missiles/micro.mdl",
-	Length		= 75,
+	Length		= 200,
 	Caliber		= 100,
 	Mass		= 100,
 	Year		= 1939,
@@ -29,13 +29,13 @@ ACF.RegisterMissile("100kgGBOMB", "GBOMB", {
 		Thrust			= 1, 	-- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
-		MinSpeed		= 500,
-		DragCoef		= 0.0001,
-		FinMul			= 5,
-		TailFinMul		= 3,
+		MinSpeed		= 1,
+		DragCoef		= 0.02,
+		FinMul			= 0.035,
+		TailFinMul		= 0.1,
 		PenMul			= math.sqrt(0.6),
-		ActualLength 	= 50,
-		ActualWidth		= 11.4
+		ActualLength 	= 100,
+		ActualWidth		= 10
 	},
 })
 
@@ -61,10 +61,10 @@ ACF.RegisterMissile("250kgGBOMB", "GBOMB", {
 		Thrust			= 1, 	-- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
-		MinSpeed		= 500,
-		DragCoef		= 0.001,
-		FinMul			= 5,
-		TailFinMul		= 3,
+		MinSpeed		= 1,
+		DragCoef		= 0.02,
+		FinMul			= 0.1,
+		TailFinMul		= 0.2,
 		PenMul			= math.sqrt(0.6),
 		ActualLength 	= 67,
 		ActualWidth		= 15

--- a/lua/acf/shared/missiles/gbomb.lua
+++ b/lua/acf/shared/missiles/gbomb.lua
@@ -33,7 +33,7 @@ ACF.RegisterMissile("100kgGBOMB", "GBOMB", {
 		DragCoef		= 0.02,
 		FinMul			= 0.035,
 		TailFinMul		= 0.1,
-		PenMul			= math.sqrt(0.6),
+		PenMul			= math.sqrt(0.3),
 		ActualLength 	= 100,
 		ActualWidth		= 10
 	},
@@ -65,7 +65,7 @@ ACF.RegisterMissile("250kgGBOMB", "GBOMB", {
 		DragCoef		= 0.02,
 		FinMul			= 0.1,
 		TailFinMul		= 0.2,
-		PenMul			= math.sqrt(0.6),
+		PenMul			= math.sqrt(0.3),
 		ActualLength 	= 67,
 		ActualWidth		= 15
 	},

--- a/lua/acf/shared/missiles/gbu.lua
+++ b/lua/acf/shared/missiles/gbu.lua
@@ -36,6 +36,7 @@ ACF.RegisterMissile("WalleyeGBU", "GBU", {
 		MinSpeed		= 500,
 		DragCoef		= 0.00001,
 		FinMul			= 1.2,
+		TailFinMul		= 30,
 		PenMul			= math.sqrt(0.5),
 		ActualLength 	= 137,
 		ActualWidth		= 16
@@ -87,6 +88,7 @@ ACF.RegisterMissile("227kgGBU", "GBU", {
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
 		FinMul			= 1.2,
+		TailFinMul		= 10,
 		PenMul			= math.sqrt(0.4),
 		ActualLength 	= 86.8,
 		ActualWidth		= 9.5
@@ -137,6 +139,7 @@ ACF.RegisterMissile("454kgGBU", "GBU", {
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
 		FinMul			= 1.2,
+		TailFinMul		= 10,
 		PenMul			= math.sqrt(0.3),
 		ActualLength 	= 101.5,
 		ActualWidth		= 12.2
@@ -188,6 +191,7 @@ ACF.RegisterMissile("909kgGBU", "GBU", {
 		MinSpeed		= 1,
 		DragCoef		= 0.002,
 		FinMul			= 0.6,
+		TailFinMul		= 20,
 		PenMul			= math.sqrt(0.2),
 		ActualLength 	= 126.1,
 		ActualWidth		= 17.8

--- a/lua/acf/shared/missiles/gbu.lua
+++ b/lua/acf/shared/missiles/gbu.lua
@@ -10,9 +10,9 @@ ACF.RegisterMissileClass("GBU", {
 
 ACF.RegisterMissile("WalleyeGBU", "GBU", {
 	Name		= "AGM-62 Walleye",
-	Description	= "An early guided bomb of yield roughly between the 454kg and 227kg, used over Vietnam by American strike aircraft.",
+	Description	= "An early TV guided bomb, used over Vietnam by American strike aircraft.",
 	Model		= "models/bombs/gbu/agm62.mdl",
-	Length		= 3450,
+	Length		= 345,
 	Caliber		= 318,
 	Mass		= 510,
 	Year		= 1967,
@@ -27,19 +27,19 @@ ACF.RegisterMissile("WalleyeGBU", "GBU", {
 	ArmDelay	= 1,
 	Round = {
 		Model			= "models/bombs/gbu/agm62.mdl",
-		MaxLength		= 80,
+		MaxLength		= 345,
 		Armor			= 10,
 		PropMass		= 1,
 		Thrust			= 1,	-- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 500,
-		DragCoef		= 0.00001,
-		FinMul			= 1.2,
-		TailFinMul		= 30,
+		DragCoef		= 0.06,
+		FinMul			= 0.3,
+		TailFinMul		= 1,
 		PenMul			= math.sqrt(0.5),
-		ActualLength 	= 137,
-		ActualWidth		= 16
+		ActualLength 	= 345,
+		ActualWidth		= 31.8
 	},
 })
 
@@ -47,8 +47,8 @@ ACF.RegisterMissile("227kgGBU", "GBU", {
 	Name		= "227kg GBU-12 Paveway II",
 	Description	= "Based on the Mk 82 500-pound general-purpose bomb, but with the addition of a nose-mounted laser seeker and fins for guidance.",
 	Model		= "models/bombs/gbu/gbu12.mdl",
-	Length		= 5000,
-	Caliber		= 105,
+	Length		= 327,
+	Caliber		= 273,
 	Mass		= 227,
 	Year		= 1976,
 	Diameter	= 10 * 25.4, -- in mm
@@ -79,19 +79,19 @@ ACF.RegisterMissile("227kgGBU", "GBU", {
 	Round = {
 		Model			= "models/bombs/gbu/gbu12_fold.mdl",
 		RackModel		= "models/bombs/gbu/gbu12.mdl",
-		MaxLength		= 250,
+		MaxLength		= 220,
 		Armor			= 10,
 		PropMass		= 0,
 		Thrust			= 1, 	-- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
-		DragCoef		= 0.002,
-		FinMul			= 1.2,
-		TailFinMul		= 10,
+		DragCoef		= 0.03,
+		FinMul			= 0.15,
+		TailFinMul		= 0.5,
 		PenMul			= math.sqrt(0.4),
-		ActualLength 	= 86.8,
-		ActualWidth		= 9.5
+		ActualLength 	= 327,
+		ActualWidth		= 27.3
 	},
 })
 
@@ -99,8 +99,8 @@ ACF.RegisterMissile("454kgGBU", "GBU", {
 	Name		= "454kg GBU-16 Paveway II",
 	Description	= "Based on the Mk 83 general-purpose bomb, but with laser seeker and wings for guidance.",
 	Model		= "models/bombs/gbu/gbu16.mdl",
-	Length		= 15000,
-	Caliber		= 170,
+	Length		= 370,
+	Caliber		= 360,
 	Mass		= 454,
 	Year		= 1976,
 	Diameter	= 11.5 * 25.4, -- in mm
@@ -130,19 +130,19 @@ ACF.RegisterMissile("454kgGBU", "GBU", {
 	Round = {
 		Model			= "models/bombs/gbu/gbu16_fold.mdl",
 		RackModel		= "models/bombs/gbu/gbu16.mdl",
-		MaxLength		= 500,
+		MaxLength		= 250,
 		Armor			= 10,
 		PropMass		= 0,
 		Thrust			= 1, 	-- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
-		DragCoef		= 0.002,
-		FinMul			= 1.2,
-		TailFinMul		= 10,
+		DragCoef		= 0.04,
+		FinMul			= 0.3,
+		TailFinMul		= 2,
 		PenMul			= math.sqrt(0.3),
-		ActualLength 	= 101.5,
-		ActualWidth		= 12.2
+		ActualLength 	= 370,
+		ActualWidth		= 36
 	},
 })
 
@@ -150,8 +150,8 @@ ACF.RegisterMissile("909kgGBU", "GBU", {
 	Name		= "909kg GBU-10 Paveway II",
 	Description	= "Based on the Mk 84 general-purpose bomb, but with laser seeker and wings for guidance.",
 	Model		= "models/bombs/gbu/gbu10.mdl",
-	Length		= 30000,
-	Caliber		= 200,
+	Length		= 434,
+	Caliber		= 460,
 	Mass		= 909,
 	Year		= 1976,
 	Diameter	= 17 * 25.4, -- in mm
@@ -182,18 +182,18 @@ ACF.RegisterMissile("909kgGBU", "GBU", {
 	Round = {
 		Model			= "models/bombs/gbu/gbu10_fold.mdl",
 		RackModel		= "models/bombs/gbu/gbu10.mdl",
-		MaxLength		= 510,
+		MaxLength		= 320,
 		Armor			= 10,
 		PropMass		= 0,
 		Thrust			= 1, 	-- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
 		StarterPercent	= 0.005,
 		MinSpeed		= 1,
-		DragCoef		= 0.002,
-		FinMul			= 0.6,
-		TailFinMul		= 20,
+		DragCoef		= 0.5,
+		FinMul			= 0.5,
+		TailFinMul		= 4,
 		PenMul			= math.sqrt(0.2),
-		ActualLength 	= 126.1,
-		ActualWidth		= 17.8
+		ActualLength 	= 434,
+		ActualWidth		= 46
 	},
 })

--- a/lua/acf/shared/missiles/gbu.lua
+++ b/lua/acf/shared/missiles/gbu.lua
@@ -37,7 +37,7 @@ ACF.RegisterMissile("WalleyeGBU", "GBU", {
 		DragCoef		= 0.06,
 		FinMul			= 0.3,
 		TailFinMul		= 1,
-		PenMul			= math.sqrt(0.5),
+		PenMul			= math.sqrt(0.2),
 		ActualLength 	= 345,
 		ActualWidth		= 31.8
 	},
@@ -89,7 +89,7 @@ ACF.RegisterMissile("227kgGBU", "GBU", {
 		DragCoef		= 0.03,
 		FinMul			= 0.15,
 		TailFinMul		= 0.5,
-		PenMul			= math.sqrt(0.4),
+		PenMul			= math.sqrt(0.2),
 		ActualLength 	= 327,
 		ActualWidth		= 27.3
 	},
@@ -140,7 +140,7 @@ ACF.RegisterMissile("454kgGBU", "GBU", {
 		DragCoef		= 0.04,
 		FinMul			= 0.3,
 		TailFinMul		= 2,
-		PenMul			= math.sqrt(0.3),
+		PenMul			= math.sqrt(0.2),
 		ActualLength 	= 370,
 		ActualWidth		= 36
 	},

--- a/lua/acf/shared/missiles/sam.lua
+++ b/lua/acf/shared/missiles/sam.lua
@@ -37,6 +37,7 @@ ACF.RegisterMissile("FIM-92 SAM", "SAM", {
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.0001,
 		FinMul			= 1.2,
+		TailFinMul		= 0.002,
 		ActualLength 	= 59,
 		ActualWidth		= 2.7
 	},
@@ -71,6 +72,7 @@ ACF.RegisterMissile("Strela-1 SAM", "SAM", {
 		DragCoef		= 0.003,
 		DragCoefFlight	= 0,
 		FinMul			= 1.8,
+		TailFinMul		= 0.002,
 		ActualLength 	= 86.5,
 		ActualWidth		= 5.5
 	},

--- a/lua/acf/shared/missiles/sam.lua
+++ b/lua/acf/shared/missiles/sam.lua
@@ -12,7 +12,7 @@ ACF.RegisterMissile("FIM-92 SAM", "SAM", {
 	Name		= "FIM-92 Stinger",
 	Description	= "The FIM-92 Stinger is a lightweight and versatile close-range air defense missile.",
 	Model		= "models/missiles/fim_92.mdl",
-	Length		= 66,
+	Length		= 152,
 	Caliber		= 70,
 	Mass		= 10,
 	Year		= 1978,
@@ -27,19 +27,18 @@ ACF.RegisterMissile("FIM-92 SAM", "SAM", {
 	Round = {
 		Model			= "models/missiles/fim_92.mdl",
 		RackModel		= "models/missiles/fim_92_folded.mdl",
-		MaxLength		= 100,
+		MaxLength		= 152,
 		Armor			= 5,
-		PropMass		= 1.5,
-		Thrust			= 7000, -- in kg*in/s^2
-		FuelConsumption = 0.14,	-- in g/s/f
+		PropMass		= 4,
+		Thrust			= 100000,	-- in kg*in/s^2
+		FuelConsumption = 0.03,		-- in g/s/f
 		StarterPercent	= 0.1,
 		MinSpeed		= 3000,
-		DragCoef		= 0.001,
-		DragCoefFlight	= 0.0001,
-		FinMul			= 1.2,
-		TailFinMul		= 0.002,
-		ActualLength 	= 59,
-		ActualWidth		= 2.7
+		DragCoef		= 0.003,
+		FinMul			= 0.03,
+		TailFinMul		= 0.001,
+		ActualLength 	= 152,
+		ActualWidth		= 7
 	},
 })
 

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -48,6 +48,7 @@ ACF.RegisterMissile("RS82 ASR", "UAR", {
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.025,
 		FinMul			= 4.8,
+		TailFinMul		= 0.04,
 		PenMul			= math.sqrt(6.63),
 		ActualLength 	= 25.2,
 		ActualWidth		= 3
@@ -82,6 +83,7 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 		DragCoef		= 0.002,
 		DragCoefFlight	= 0.02,
 		FinMul			= 0.6,
+		TailFinMul		= 0.3,
 		PenMul			= math.sqrt(6.25),
 		ActualLength 	= 69, -- nice
 		ActualWidth		= 5
@@ -114,6 +116,7 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 		DragCoefFlight	= 0.05,
 		DragCoef		= 0.005,
 		FinMul			= 1.2,
+		TailFinMul		= 0.1,
 		PenMul			= math.sqrt(4.5),
 		ActualLength 	= 25.4,
 		ActualWidth		= 4.2
@@ -146,7 +149,8 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 		MinSpeed		= 10000,
 		DragCoef		= 0.001,
 		DragCoefFlight	= 0.01,
-		FinMul			= 1.2,
+		FinMul			= 0.8,
+		TailFinMul		= 1,
 		PenMul			= math.sqrt(5),
 		ActualLength 	= 89.3,
 		ActualWidth		= 9
@@ -180,7 +184,8 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 		StarterPercent	= 0.05,
 		MinSpeed		= 1,
 		DragCoef		= 0,
-		FinMul			= 0.06,
+		FinMul			= 0,
+		TailFinMul		= 100,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 65,
 		ActualWidth		= 16.4

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -40,7 +40,7 @@ ACF.RegisterMissile("RS82 ASR", "UAR", {
 		Model			= "models/missiles/rs82.mdl",
 		MaxLength		= 60,
 		Armor			= 5,
-		PropMass		= 2.5,
+		PropMass		= 1.25,
 		Thrust			= 40000,	-- in kg*in/s^2
 		FuelConsumption = 0.08,		-- in g/s/f
 		StarterPercent	= 0.15,
@@ -48,7 +48,7 @@ ACF.RegisterMissile("RS82 ASR", "UAR", {
 		DragCoef		= 0.001,
 		FinMul			= 0.01,
 		TailFinMul		= 0.05,
-		PenMul			= math.sqrt(7),
+		PenMul			= math.sqrt(2),
 		ActualLength 	= 60,
 		ActualWidth		= 8.2
 	},
@@ -74,7 +74,7 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 		RackModel		= "models/missiles/hvar_folded.mdl",
 		MaxLength		= 173,
 		Armor			= 5,
-		PropMass		= 16,
+		PropMass		= 9,
 		Thrust			= 270000,	-- in kg*in/s^2
 		FuelConsumption = 0.053,	-- in g/s/f
 		StarterPercent	= 0.15,
@@ -82,7 +82,7 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 		DragCoef		= 0.005,
 		FinMul			= 0.01,
 		TailFinMul		= 0.075,
-		PenMul			= math.sqrt(3.95),
+		PenMul			= math.sqrt(1),
 		ActualLength 	= 173,
 		ActualWidth		= 12.7
 	},
@@ -106,7 +106,7 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 		RackModel		= "models/munitions/round_100mm_mortar_shot.mdl",
 		MaxLength		= 100,
 		Armor			= 5,
-		PropMass		= 2,
+		PropMass		= 1.5,
 		Thrust			= 300000,	-- in kg*in/s^2
 		FuelConsumption = 0.019,		-- in g/s/f
 		StarterPercent	= 0.95,
@@ -114,7 +114,7 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 		DragCoef		= 0.005,
 		FinMul			= 0.002,
 		TailFinMul		= 0.02,
-		PenMul			= math.sqrt(5.6),
+		PenMul			= math.sqrt(3),
 		ActualLength 	= 100,
 		ActualWidth		= 7.3
 	},
@@ -139,7 +139,7 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 		Model			= "models/missiles/s24.mdl",
 		MaxLength		= 233,
 		Armor			= 5,
-		PropMass		= 70,
+		PropMass		= 40,
 		Thrust			= 2000000,	-- in kg*in/s^2
 		FuelConsumption = 0.052,	-- in g/s/f
 		StarterPercent	= 0.15,
@@ -147,7 +147,7 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 		DragCoef		= 0.01,
 		FinMul			= 0.1,
 		TailFinMul		= 0.3,
-		PenMul			= math.sqrt(5),
+		PenMul			= math.sqrt(1.5),
 		ActualLength 	= 233,
 		ActualWidth		= 24
 	},
@@ -174,7 +174,7 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 		RackModel		= "models/missiles/RW61M.mdl",
 		MaxLength		= 150,
 		Armor			= 5,
-		PropMass		= 70,
+		PropMass		= 60,
 		Thrust			= 500000,	-- in kg*in/s^2
 		FuelConsumption = 0.048,		-- in g/s/f
 		StarterPercent	= 0.2,
@@ -182,7 +182,7 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 		DragCoef		= 0.02,
 		FinMul			= 0,
 		TailFinMul		= 10,
-		PenMul			= math.sqrt(2),
+		PenMul			= math.sqrt(1),
 		ActualLength 	= 150,
 		ActualWidth		= 38
 	},

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -14,7 +14,7 @@ ACF.RegisterMissile("RS82 ASR", "UAR", {
 	Model		= "models/missiles/rs82.mdl",
 	Caliber		= 82,
 	Mass		= 7,
-	Length		= 40,
+	Length		= 60,
 	Diameter	= 2.2 * 25.4, -- in mm
 	ReloadTime	= 5,
 	Offset		= Vector(1, 0, 0),
@@ -38,20 +38,19 @@ ACF.RegisterMissile("RS82 ASR", "UAR", {
 	},
 	Round = {
 		Model			= "models/missiles/rs82.mdl",
-		MaxLength		= 25,
+		MaxLength		= 60,
 		Armor			= 5,
-		PropMass		= 0.7,
-		Thrust			= 15000,	-- in kg*in/s^2
-		FuelConsumption = 0.05,		-- in g/s/f
+		PropMass		= 2.5,
+		Thrust			= 40000,	-- in kg*in/s^2
+		FuelConsumption = 0.08,		-- in g/s/f
 		StarterPercent	= 0.15,
 		MinSpeed		= 6000,
-		DragCoef		= 0.002,
-		DragCoefFlight	= 0.025,
-		FinMul			= 4.8,
-		TailFinMul		= 0.04,
-		PenMul			= math.sqrt(6.63),
-		ActualLength 	= 25.2,
-		ActualWidth		= 3
+		DragCoef		= 0.001,
+		FinMul			= 0.01,
+		TailFinMul		= 0.05,
+		PenMul			= math.sqrt(7),
+		ActualLength 	= 60,
+		ActualWidth		= 8.2
 	},
 })
 
@@ -61,7 +60,7 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 	Model		= "models/missiles/hvar.mdl",
 	Caliber		= 127,
 	Mass		= 64,
-	Length		= 44,
+	Length		= 173,
 	Diameter	= 4 * 25.4, -- in mm
 	ReloadTime	= 10,
 	Offset		= Vector(2, 0, 0),
@@ -73,20 +72,19 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 	Round = {
 		Model			= "models/missiles/hvar.mdl",
 		RackModel		= "models/missiles/hvar_folded.mdl",
-		MaxLength		= 25,
+		MaxLength		= 173,
 		Armor			= 5,
-		PropMass		= 0.7,
-		Thrust			= 25000,	-- in kg*in/s^2
-		FuelConsumption = 0.024,	-- in g/s/f
-		StarterPercent	= 0.05,
+		PropMass		= 16,
+		Thrust			= 270000,	-- in kg*in/s^2
+		FuelConsumption = 0.053,	-- in g/s/f
+		StarterPercent	= 0.15,
 		MinSpeed		= 5000,
-		DragCoef		= 0.002,
-		DragCoefFlight	= 0.02,
-		FinMul			= 0.6,
-		TailFinMul		= 0.3,
-		PenMul			= math.sqrt(6.25),
-		ActualLength 	= 69, -- nice
-		ActualWidth		= 5
+		DragCoef		= 0.005,
+		FinMul			= 0.01,
+		TailFinMul		= 0.075,
+		PenMul			= math.sqrt(3.95),
+		ActualLength 	= 173,
+		ActualWidth		= 12.7
 	},
 })
 
@@ -96,7 +94,7 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 	Model		= "models/munitions/round_100mm_mortar_shot.mdl",
 	Caliber		= 73,
 	Mass		= 5,
-	Length		= 20,
+	Length		= 100,
 	Year		= 1962,
 	ReloadTime	= 10,
 	Racks		= { ["1x SPG9"] = true },
@@ -106,20 +104,19 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 	Round = {
 		Model			= "models/missiles/glatgm/9m112f.mdl",
 		RackModel		= "models/munitions/round_100mm_mortar_shot.mdl",
-		MaxLength		= 50,
+		MaxLength		= 100,
 		Armor			= 5,
-		PropMass		= 0.5,
-		Thrust			= 100000,	-- in kg*in/s^2 very high but only burns a brief moment, most of which is in the tube
-		FuelConsumption = 0.07,		-- in g/s/f
-		StarterPercent	= 0.9,
+		PropMass		= 2,
+		Thrust			= 300000,	-- in kg*in/s^2
+		FuelConsumption = 0.019,		-- in g/s/f
+		StarterPercent	= 0.95,
 		MinSpeed		= 900,
-		DragCoefFlight	= 0.05,
 		DragCoef		= 0.005,
-		FinMul			= 1.2,
-		TailFinMul		= 0.1,
-		PenMul			= math.sqrt(4.5),
-		ActualLength 	= 25.4,
-		ActualWidth		= 4.2
+		FinMul			= 0.002,
+		TailFinMul		= 0.02,
+		PenMul			= math.sqrt(5.6),
+		ActualLength 	= 100,
+		ActualWidth		= 7.3
 	},
 })
 
@@ -129,7 +126,7 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 	Model		= "models/missiles/s24.mdl",
 	Caliber		= 240,
 	Mass		= 235,
-	Length		= 25,
+	Length		= 233,
 	Diameter	= 8.3 * 25.4, -- in mm
 	ReloadTime	= 20,
 	Year		= 1960,
@@ -140,20 +137,19 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 	ArmDelay	= 0.3,
 	Round = {
 		Model			= "models/missiles/s24.mdl",
-		MaxLength		= 40,
+		MaxLength		= 233,
 		Armor			= 5,
-		PropMass		= 15,
-		Thrust			= 9000, -- in kg*in/s^2
-		FuelConsumption = 0.1,	-- in g/s/f
-		StarterPercent	= 0.05,
+		PropMass		= 70,
+		Thrust			= 2000000,	-- in kg*in/s^2
+		FuelConsumption = 0.052,	-- in g/s/f
+		StarterPercent	= 0.15,
 		MinSpeed		= 10000,
-		DragCoef		= 0.001,
-		DragCoefFlight	= 0.01,
-		FinMul			= 0.8,
-		TailFinMul		= 1,
+		DragCoef		= 0.01,
+		FinMul			= 0.1,
+		TailFinMul		= 0.3,
 		PenMul			= math.sqrt(5),
-		ActualLength 	= 89.3,
-		ActualWidth		= 9
+		ActualLength 	= 233,
+		ActualWidth		= 24
 	},
 })
 
@@ -163,7 +159,7 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 	Model		= "models/missiles/RW61M.mdl",
 	Caliber		= 380,
 	Mass		= 476,
-	Length		= 38,
+	Length		= 150,
 	Year		= 1960,
 	ReloadTime	= 40,
 	Racks		= { ["380mmRW61"] = true },
@@ -176,18 +172,18 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 	Round = {
 		Model			= "models/missiles/RW61M.mdl",
 		RackModel		= "models/missiles/RW61M.mdl",
-		MaxLength		= 60,
+		MaxLength		= 150,
 		Armor			= 5,
-		PropMass		= 5,
-		Thrust			= 5000, -- in kg*in/s^2
-		FuelConsumption = 1,	-- in g/s/f
-		StarterPercent	= 0.05,
+		PropMass		= 70,
+		Thrust			= 500000,	-- in kg*in/s^2
+		FuelConsumption = 0.048,		-- in g/s/f
+		StarterPercent	= 0.2,
 		MinSpeed		= 1,
-		DragCoef		= 0,
+		DragCoef		= 0.02,
 		FinMul			= 0,
-		TailFinMul		= 100,
+		TailFinMul		= 10,
 		PenMul			= math.sqrt(2),
-		ActualLength 	= 65,
-		ActualWidth		= 16.4
+		ActualLength 	= 150,
+		ActualWidth		= 38
 	},
 })

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -193,21 +193,13 @@ local function CalcFlight(Missile)
 		Missile.LastLOS = LOS
 	else
 		local DirAng = Dir:Angle()
-		local AimDiff = Dir - VelNorm
-		local DiffLength = AimDiff:Length()
+		local Torque = Dir:Cross(LastVel) * LastSpeed * Missile.TorqueMul / Missile.Inertia
 
-		if DiffLength >= 0.001 then
-			local Torque = DiffLength * Missile.TorqueMul
-			local AngVelDiff = Torque / Missile.Inertia * DeltaTime
-			local DiffAxis = AimDiff:Cross(Dir):GetNormalized()
-
-			Missile.RotAxis = Missile.RotAxis + DiffAxis * AngVelDiff * DeltaTime
-		end
-
+		Missile.RotAxis = Missile.RotAxis + Torque * DeltaTime
+		DirAng:RotateAroundAxis(Missile.RotAxis:GetNormalized(), Missile.RotAxis:Length() * DeltaTime)
 		Missile.RotAxis = Missile.RotAxis * 0.99
-		Missile.LastLOS = nil
 
-		DirAng:RotateAroundAxis(Missile.RotAxis:GetNormalized(), Missile.RotAxis:Length())
+		Missile.LastLOS = nil
 
 		Dir = DirAng:Forward()
 	end
@@ -362,7 +354,7 @@ function MakeACF_Missile(Player, Pos, Ang, Rack, MountPoint, Crate)
 	Missile.Agility        	= Data.Agility or 1
 	Missile.Inertia        	= 0.08333 * Data.Mass * (3.1416 * (Caliber * 0.05) ^ 2 + Length)
 	Missile.Length         	= Length
-	Missile.TorqueMul      	= Length * 1500
+	Missile.TorqueMul      	= Length * 0.0005 * Round.TailFinMul
 	Missile.RotAxis        	= Vector()
 	Missile.UseGuidance    	= true
 	Missile.MotorEnabled   	= false

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -6,7 +6,8 @@ include("shared.lua")
 
 local ACF            = ACF
 local TraceData      = { start = true, endpos = true, filter = true }
-local Gravity        = Vector(0, 0, -GetConVar("sv_gravity"):GetFloat())
+local GravityCvar    = GetConVar("sv_gravity")
+local GravityVector  = Vector(0, 0, -GravityCvar:GetFloat())
 local GhostPeriod    = GetConVar("ACFM_GhostPeriod")
 local ActiveMissiles = ACF.ActiveMissiles
 local Missiles       = ACF.Classes.Missiles
@@ -148,7 +149,7 @@ local function CalcFlight(Missile)
 	if TargetPos then
 		local Dist = Pos:Distance(TargetPos)
 
-		TargetPos = TargetPos + Vector(0, 0, Gravity:GetFloat() * Dist / 100000)
+		TargetPos = TargetPos + Vector(0, 0, GravityCvar:GetFloat() * Dist / 100000)
 
 		local LOS = (TargetPos - Pos):GetNormalized()
 		local LastLOS = Missile.LastLOS
@@ -222,7 +223,7 @@ local function CalcFlight(Missile)
 	local DotSimple = Up.x * LastVel.x + Up.y * LastVel.y + Up.z * LastVel.z
 	local Lift      = -Up * LastSpeed * DotSimple * Missile.FinMultiplier
 	local Drag      = LastVel * (Missile.DragCoef * LastSpeed) / ACF.DragDiv * ACF.Scale
-	local Vel       = LastVel + (Gravity + (Thrust + Lift - Drag) / Missile.Mass) * DeltaTime
+	local Vel       = LastVel + (GravityVector + (Thrust + Lift - Drag) / Missile.Mass) * DeltaTime
 	local EndPos    = Pos + Vel * DeltaTime
 
 	Missile.Velocity = Vel
@@ -275,7 +276,7 @@ local function DetonateMissile(Missile, Inflictor)
 end
 
 cvars.AddChangeCallback("sv_gravity", function(_, _, Value)
-	Gravity.z = -Value
+	GravityVector.z = -Value
 end, "ACF Missile Gravity")
 
 hook.Add("CanDrive", "acf_missile_CanDrive", function(_, Entity)


### PR DESCRIPTION
Reworked the way missiles with no guidance and rockets turn.  Added a new property to each missile, `TailFinMul` (Tail fin multiplier) which increases the torque applied on the missile when it's AoA increases. A missile with a high `TailFinMul` will follow it's prograde vector more closely.

Torque is now proportional to the speed squared, like irl. Also simplified the way it is calculated a good bit.

Adjusted the values of `TailFinMul` and `FinMul` to balance the missiles. Missiles which are meant to be guided get low a `TailFinMul`, giving them a more or less straight trajectory (to help acquire a lock instead of pitching down as they fly). Rockets, get a high `TailFinMul` to follow the prograde vector more closely and impact at low angles of attack (no more FFARs impacting at huge angles, making HEAT useless on them). Artillery rockets had their stats tweaked to help them turn in high arcing trajectories, instead of flipping.