### PR TITLE
Added maximum warhead size to missiles, rebalanced penetration and flight

### DIFF
--- a/lua/acf/shared/missiles/aam.lua
+++ b/lua/acf/shared/missiles/aam.lua
@@ -24,18 +24,19 @@ ACF.RegisterMissile("AIM-9 AAM", "AAM", {
 	Fuzes		= { Contact = true, Radio = true },
 	SeekCone	= 10,
 	ViewCone	= 30,
-	Agility		= 0.0035,
+	Agility		= 0.0017,
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/aim9m.mdl",
 		MaxLength		= 289,
+		ProjLength		= 68,
 		Armor			= 5,
 		PropLength		= 160,
 		Thrust			= 800000,	-- in kg*in/s^2
 		FuelConsumption = 0.02,		-- in g/s/f
 		StarterPercent	= 0.05,
 		MaxAgilitySpeed = 300,      -- in m/s
-		DragCoef		= 0.015,
+		DragCoef		= 0.005,
 		FinMul			= 0.1,
 		GLimit          = 20,
 		TailFinMul		= 0.001,
@@ -65,18 +66,19 @@ ACF.RegisterMissile("AIM-120 AAM", "AAM", {
 	Fuzes		= { Contact = true, Radio = true },
 	SeekCone	= 10,
 	ViewCone	= 30,
-	Agility		= 0.015,
+	Agility		= 0.006,
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/aim120c.mdl",
 		MaxLength		= 370,
 		Armor			= 5,
-		PropLength		= 200,
-		Thrust			= 1200000, 	-- in kg*in/s^2
+		ProjLength		= 70,
+		PropLength		= 140,
+		Thrust			= 1500000, 	-- in kg*in/s^2
 		FuelConsumption = 0.02,		-- in g/s/f
 		StarterPercent	= 0.05,
 		MaxAgilitySpeed = 350,      -- in m/s
-		DragCoef		= 0.02,
+		DragCoef		= 0.01,
 		FinMul			= 0.2,
 		GLimit          = 20,
 		TailFinMul		= 0.001,
@@ -102,22 +104,23 @@ ACF.RegisterMissile("AIM-54 AAM", "AAM", {
 	ReloadTime	= 40,
 	Racks		= { ["1xRK"] = true, ["2xRK"] = true },
 	Guidance	= { Dumb = true, ["Semi-Active Radar"] = true, ["Active Radar"] = true },
-	Navigation  = "PN",
+	Navigation  = "APN",
 	Fuzes		= { Contact = true, Radio = true },
 	SeekCone	= 10,
 	ViewCone	= 20,
-	Agility		= 0.04,
+	Agility		= 0.02,
 	ArmDelay	= 0.4,
 	Round = {
 		Model			= "models/missiles/aim54.mdl",
 		MaxLength		= 400,
 		Armor			= 5,
-		PropLength		= 250,
-		Thrust			= 5200000,	-- in kg*in/s^2
+		ProjLength		= 60,
+		PropLength		= 220,
+		Thrust			= 4000000,	-- in kg*in/s^2
 		FuelConsumption = 0.04,		-- in g/s/f
-		StarterPercent	= 0.01,
+		StarterPercent	= 0.05,
 		MaxAgilitySpeed = 300,      -- in m/s
-		DragCoef		= 0.1,
+		DragCoef		= 0.03,
 		FinMul			= 0.3,
 		GLimit          = 12,
 		TailFinMul		= 0.001,

--- a/lua/acf/shared/missiles/arm.lua
+++ b/lua/acf/shared/missiles/arm.lua
@@ -24,12 +24,13 @@ ACF.RegisterMissile("AGM-122 ASM", "ARM", {
 	Fuzes		= { Contact = true, Optical = true },
 	SeekCone	= 10,
 	ViewCone	= 20,
-	Agility		= 0.0035,
+	Agility		= 0.0018,
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/aim9.mdl",
 		MaxLength		= 287,
 		Armor			= 5,
+		ProjLength		= 68,
 		PropLength		= 160,
 		Thrust			= 800000,	-- in kg*in/s^2
 		FuelConsumption = 0.02,		-- in g/s/f
@@ -64,12 +65,13 @@ ACF.RegisterMissile("AGM-45 ASM", "ARM", {
 	Fuzes		= { Contact = true, Timed = true },
 	SeekCone	= 5,
 	ViewCone	= 10,
-	Agility		= 0.015,
+	Agility		= 0.012,
 	ArmDelay	= 0.3,
 	Round = {
 		Model			= "models/missiles/aim120.mdl",
 		MaxLength		= 305,
 		Armor			= 5,
+		ProjLength		= 70,
 		PropLength		= 200,
 		Thrust			= 1500000, 	-- in kg*in/s^2
 		FuelConsumption = 0.020,		-- in g/s/f

--- a/lua/acf/shared/missiles/arty.lua
+++ b/lua/acf/shared/missiles/arty.lua
@@ -29,6 +29,7 @@ ACF.RegisterMissile("Type 63 RA", "ARTY", {
 		Model			= "models/missiles/glatgm/mgm51.mdl",
 		MaxLength		= 80,
 		Armor			= 5,
+		ProjLength		= 35,
 		PropLength		= 45,
 		Thrust			= 240000,	-- in kg*in/s^2
 		FuelConsumption = 0.06, 	-- in g/s/f
@@ -38,7 +39,7 @@ ACF.RegisterMissile("Type 63 RA", "ARTY", {
 		FinMul			= 0,
 		GLimit          = 10,
 		TailFinMul		= 2,
-		PenMul			= math.sqrt(2),
+		PenMul			= 2,
 		ActualLength 	= 80,
 		ActualWidth		= 10.7
 	},
@@ -69,6 +70,7 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 		Model		= "models/missiles/9m31.mdl",
 		MaxLength		= 287,
 		Armor			= 5,
+		ProjLength		= 100,
 		PropLength		= 160,
 		Thrust			= 800000,   -- in kg*in/s^2
 		FuelConsumption = 0.012,    -- in g/s/f
@@ -78,7 +80,7 @@ ACF.RegisterMissile("SAKR-10 RA", "ARTY", {
 		FinMul			= 0.1,
 		GLimit          = 5,
 		TailFinMul		= 2,
-		PenMul			= math.sqrt(0.5),
+		PenMul			= 1.2,
 		ActualLength 	= 287,
 		ActualWidth		= 12.2
 	},
@@ -109,6 +111,7 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 		Model		= "models/missiles/aim120.mdl",
 		MaxLength		= 370,
 		Armor			= 5,
+		ProjLength		= 140,
 		PropLength		= 200,
 		Thrust			= 2400000,	-- in kg*in/s^2
 		FuelConsumption = 0.022,	-- in g/s/f
@@ -118,7 +121,7 @@ ACF.RegisterMissile("SS-40 RA", "ARTY", {
 		FinMul			= 0.12,
 		GLimit          = 5,
 		TailFinMul		= 10,
-		PenMul			= math.sqrt(0.5),
+		PenMul			= 1.4,
 		ActualLength 	= 370,
 		ActualWidth		= 18
 	},

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -23,22 +23,23 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 	Guidance	= { Dumb = true, ["Wire (MCLOS)"] = true, ["Wire (SACLOS)"] = true },
 	Fuzes		= { Contact = true, Optical = true },
 	SkinIndex	= { HEAT = 0, HE = 1 },
-	Agility		= 0.0002,
+	Agility		= 0.00022,
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/at3.mdl",
 		MaxLength		= 86,
 		Armor			= 5,
+		ProjLength		= 30,
 		PropLength		= 45,
-		Thrust			= 11000,    -- in kg*in/s^2
+		Thrust			= 4000,     -- in kg*in/s^2
 		FuelConsumption = 0.05,     -- in g/s/f
-		StarterPercent	= 0.25,
+		StarterPercent	= 0.45,
 		MaxAgilitySpeed = 70,       -- in m/s
-		DragCoef		= 0.04,
+		DragCoef		= 0.01,
 		FinMul			= 0.1,
-		GLimit          = 5,
+		GLimit          = 10,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(2),
+		PenMul			= 2.64,
 		ActualLength 	= 86,
 		ActualWidth		= 12.5
 	},
@@ -61,22 +62,23 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 	Guidance	= { Dumb = true, ["Wire (SACLOS)"] = true },
 	Navigation  = "PN",
 	Fuzes		= { Contact = true, Optical = true },
-	Agility		= 0.0005,
+	Agility		= 0.00018,
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/bgm_71e.mdl",
 		MaxLength		= 117,
 		Armor			= 5,
-		PropLength		= 70,
-		Thrust			= 250000,	-- in kg*in/s^2
-		FuelConsumption = 0.045,	-- in g/s/f
+		ProjLength		= 35,
+		PropLength		= 35,
+		Thrust			= 200000,	-- in kg*in/s^2
+		FuelConsumption = 0.027,	-- in g/s/f
 		StarterPercent	= 0.2,
-		MaxAgilitySpeed = 200,      -- in m/s
+		MaxAgilitySpeed = 150,      -- in m/s
 		DragCoef		= 0.005,
 		FinMul			= 0.1,
-		GLimit          = 5,
+		GLimit          = 10,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(3),
+		PenMul			= 3.86,
 		ActualLength 	= 117,
 		ActualWidth		= 15.2
 	},
@@ -101,7 +103,7 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 40,
 	SeekCone	= 10,
-	Agility		= 0.00075,
+	Agility		= 0.0005,
 	ArmDelay	= 0.5,
 	Bodygroups = {
 		guidance = {
@@ -120,16 +122,17 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 		Model			= "models/missiles/agm_114.mdl",
 		MaxLength		= 160,
 		Armor			= 5,
-		PropLength		= 90,
-		Thrust			= 600000,   -- in kg*in/s^2
-		FuelConsumption = 0.05,     -- in g/s/f
-		StarterPercent	= 0.02,
-		MaxAgilitySpeed = 150,      -- in m/s
+		ProjLength		= 50,
+		PropLength		= 50,
+		Thrust			= 400000,   -- in kg*in/s^2
+		FuelConsumption = 0.018,     -- in g/s/f
+		StarterPercent	= 0.01,
+		MaxAgilitySpeed = 100,      -- in m/s
 		DragCoef		= 0.005,
 		FinMul			= 0.1,
-		GLimit          = 5,
+		GLimit          = 10,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(2),
+		PenMul			= 3.22,
 		ActualLength 	= 160,
 		ActualWidth		= 18
 	},
@@ -151,10 +154,10 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 	ReloadTime	= 20,
 	Racks		= { ["1x Ataka"] = true, ["1xRK"] = true, ["2xRK"] = true, ["4xRK"] = true },
 	Guidance	= { Dumb = true, ["Radio (SACLOS)"] = true },
-	Navigation  = "PN",
+	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 45,
-	Agility		= 0.00075,
+	Agility		= 0.0003,
 	ArmDelay	= 0.1,
 	NoDamage    = true,
 	Round = {
@@ -162,16 +165,17 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 		RackModel		= "models/missiles/9m120_rk1.mdl",
 		MaxLength		= 183,
 		Armor			= 5,
+		ProjLength		= 50,
 		PropLength		= 100,
-		Thrust			= 600000,   -- in kg*in/s^2
-		FuelConsumption = 0.045,    -- in g/s/f
+		Thrust			= 800000,   -- in kg*in/s^2
+		FuelConsumption = 0.03,    -- in g/s/f
 		StarterPercent	= 0.02,
 		MaxAgilitySpeed = 200,      -- in m/s
-		DragCoef		= 0.005,
+		DragCoef		= 0.002,
 		FinMul			= 0.1,
-		GLimit          = 5,
+		GLimit          = 10,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(2),
+		PenMul			= 3.09,
 		ActualLength 	= 183,
 		ActualWidth		= 13
 	},
@@ -193,10 +197,10 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 	ExhaustOffset = Vector(-29.1, 0, 0),
 	Racks		= { ["1x Kornet"] = true },
 	Guidance	= { Dumb = true, Laser = true },
-	Navigation  = "PN",
+	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 20,
-	Agility		= 0.0005,
+	Agility		= 0.0002,
 	ArmDelay	= 0.1,
 	Bodygroups = {
 		fins = {
@@ -213,16 +217,17 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		Model			= "models/kali/weapons/kornet/parts/9m133 kornet missile.mdl",
 		MaxLength		= 120,
 		Armor			= 5,
-		PropLength		= 70,
-		Thrust			= 230000,   -- in kg*in/s^2
-		FuelConsumption = 0.035,    -- in g/s/f
+		ProjLength		= 40,
+		PropLength		= 50,
+		Thrust			= 430000,   -- in kg*in/s^2
+		FuelConsumption = 0.030,    -- in g/s/f
 		StarterPercent	= 0.1,
 		MaxAgilitySpeed = 200,      -- in m/s
 		DragCoef		= 0.005,
 		FinMul			= 0.1,
 		GLimit          = 8,
 		TailFinMul		= 0.01,
-		PenMul			= math.sqrt(3.5),
+		PenMul			= 3.88,
 		ActualLength 	= 120,
 		ActualWidth		= 15.2
 	},
@@ -247,20 +252,21 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 90,
-	Agility		= 0.0005,
+	Agility		= 0.0006,
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/at2.mdl",
 		MaxLength		= 116,
 		Armor			= 5,
-		PropLength		= 70,
-		Thrust			= 40000,    -- in kg*in/s^2
+		ProjLength		= 35,
+		PropLength		= 35,
+		Thrust			= 10000,    -- in kg*in/s^2
 		FuelConsumption = 0.035,    -- in g/s/f
-		StarterPercent	= 0.25,
+		StarterPercent	= 0.50,
 		MaxAgilitySpeed = 100,      -- in m/s
-		DragCoef		= 0.06,
+		DragCoef		= 0.015,
 		FinMul			= 0.1,
-		GLimit          = 5,
+		GLimit          = 10,
 		TailFinMul		= 0.01,
 		PenMul			= math.sqrt(2),
 		ActualLength 	= 116,

--- a/lua/acf/shared/missiles/bomb.lua
+++ b/lua/acf/shared/missiles/bomb.lua
@@ -29,6 +29,7 @@ ACF.RegisterMissile("50kgBOMB", "BOMB", {
 		Model			= "models/bombs/fab50.mdl",
 		MaxLength		= 50,
 		Armor			= 10,
+		ProjLength		= 50,
 		PropLength		= 0,
 		Thrust			= 1,    -- in kg*in/s^2
 		FuelConsumption = 0.1,  -- in g/s/f
@@ -68,6 +69,7 @@ ACF.RegisterMissile("100kgBOMB", "BOMB", {
 		Model			= "models/bombs/fab100.mdl",
 		MaxLength		= 100,
 		Armor			= 10,
+		ProjLength		= 100,
 		PropLength		= 0,
 		Thrust			= 1,    -- in kg*in/s^2
 		FuelConsumption = 0.1,  -- in g/s/f
@@ -107,6 +109,7 @@ ACF.RegisterMissile("250kgBOMB", "BOMB", {
 		Model			= "models/bombs/fab250.mdl",
 		MaxLength		= 200,
 		Armor			= 10,
+		ProjLength		= 200,
 		PropLength		= 0,
 		Thrust			= 1,    -- in kg*in/s^2
 		FuelConsumption = 0.1,  -- in g/s/f
@@ -146,6 +149,7 @@ ACF.RegisterMissile("500kgBOMB", "BOMB", {
 		Model			= "models/bombs/fab500.mdl",
 		MaxLength		= 250,
 		Armor			= 10,
+		ProjLength		= 250,
 		PropLength		= 0,
 		Thrust			= 1,    -- in kg*in/s^2
 		FuelConsumption = 0.1,  -- in g/s/f
@@ -185,6 +189,7 @@ ACF.RegisterMissile("1000kgBOMB", "BOMB", {
 		Model			= "models/bombs/an_m66.mdl",
 		MaxLength		= 375,
 		Armor			= 10,
+		ProjLength		= 375,
 		PropLength		= 0,
 		Thrust			= 1,    -- in kg*in/s^2
 		FuelConsumption = 0.1,  -- in g/s/f

--- a/lua/acf/shared/missiles/ffar.lua
+++ b/lua/acf/shared/missiles/ffar.lua
@@ -28,16 +28,17 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 		RackModel		= "models/missiles/ffar_40mm_closed.mdl",
 		MaxLength		= 60,
 		Armor			= 5,
+		ProjLength		= 25,
 		PropLength		= 35,
 		Thrust			= 150000,   -- in kg*in/s^2
 		FuelConsumption = 0.015,    -- in g/s/f
 		StarterPercent	= 0.1,
 		MaxAgilitySpeed = 1,        -- in m/s
-		DragCoef		= 0.001,
+		DragCoef		= 0.0005,
 		FinMul			= 0.01,
 		GLimit          = 1,
 		TailFinMul		= 0.005,
-		PenMul			= math.sqrt(2),
+		PenMul			= 0.8,
 		ActualLength 	= 60,
 		ActualWidth		= 4
 	},
@@ -67,16 +68,17 @@ ACF.RegisterMissile("70mmFFAR", "FFAR", {
 		RackModel		= "models/missiles/ffar_70mm_closed.mdl",
 		MaxLength		= 106,
 		Armor			= 5,
-		PropLength		= 35,
+		ProjLength		= 66,
+		PropLength		= 40,
 		Thrust			= 850000,	-- in kg*in/s^2
-		FuelConsumption = 0.010,	-- in g/s/f
+		FuelConsumption = 0.005,	-- in g/s/f
 		StarterPercent	= 0.1,
 		MaxAgilitySpeed = 1,        -- in m/s
 		DragCoef		= 0.002,
 		FinMul			= 0.01,
 		GLimit          = 1,
 		TailFinMul		= 0.005,
-		PenMul			= math.sqrt(1),
+		PenMul			= 0.85,
 		ActualLength 	= 106,
 		ActualWidth		= 7
 	},
@@ -115,7 +117,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		FinMul			= 0.005,
 		GLimit          = 1,
 		TailFinMul		= 0.04,
-		PenMul			= math.sqrt(1),
+		PenMul			= 0.8,
 		ActualLength 	= 200,
 		ActualWidth		= 12.7
 	},

--- a/lua/acf/shared/missiles/ffar.lua
+++ b/lua/acf/shared/missiles/ffar.lua
@@ -38,7 +38,7 @@ ACF.RegisterMissile("40mmFFAR", "FFAR", {
 		FinMul			= 0.01,
 		GLimit          = 1,
 		TailFinMul		= 0.005,
-		PenMul			= 0.8,
+		PenMul			= 0.91,
 		ActualLength 	= 60,
 		ActualWidth		= 4
 	},
@@ -108,6 +108,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		RackModel		= "models/ghosteh/zuni_folded.mdl",
 		MaxLength		= 200,
 		Armor			= 5,
+		ProjLength		= 90,
 		PropLength		= 110,
 		Thrust			= 800000,   -- in kg*in/s^2
 		FuelConsumption = 0.032,    -- in g/s/f
@@ -117,7 +118,7 @@ ACF.RegisterMissile("Zuni ASR", "FFAR", {
 		FinMul			= 0.005,
 		GLimit          = 1,
 		TailFinMul		= 0.04,
-		PenMul			= 0.8,
+		PenMul			= 1,
 		ActualLength 	= 200,
 		ActualWidth		= 12.7
 	},

--- a/lua/acf/shared/missiles/gbomb.lua
+++ b/lua/acf/shared/missiles/gbomb.lua
@@ -26,6 +26,7 @@ ACF.RegisterMissile("100kgGBOMB", "GBOMB", {
 		Model			= "models/missiles/micro.mdl",
 		MaxLength		= 100,
 		Armor			= 10,
+		ProjLength		= 80,
 		PropLength		= 0,
 		Thrust			= 1,    -- in kg*in/s^2
 		FuelConsumption = 0.1,  -- in g/s/f
@@ -63,6 +64,7 @@ ACF.RegisterMissile("250kgGBOMB", "GBOMB", {
 		Model			= "models/missiles/fab250.mdl",
 		MaxLength		= 250,
 		Armor			= 10,
+		ProjLength		= 200,
 		PropLength		= 0,
 		Thrust			= 1,    -- in kg*in/s^2
 		FuelConsumption = 0.1,  -- in g/s/f

--- a/lua/acf/shared/missiles/gbu.lua
+++ b/lua/acf/shared/missiles/gbu.lua
@@ -30,6 +30,7 @@ ACF.RegisterMissile("WalleyeGBU", "GBU", {
 		Model			= "models/bombs/gbu/agm62.mdl",
 		MaxLength		= 345,
 		Armor			= 10,
+		ProjLength		= 89,
 		PropLength		= 0,
 		Thrust			= 1,	-- in kg*in/s^2
 		FuelConsumption = 0.1,	-- in g/s/f
@@ -39,7 +40,7 @@ ACF.RegisterMissile("WalleyeGBU", "GBU", {
 		FinMul			= 0.3,
 		GLimit          = 3,
 		TailFinMul		= 1,
-		PenMul			= math.sqrt(0.2),
+		PenMul			= 1,
 		ActualLength 	= 345,
 		ActualWidth		= 31.8
 	},
@@ -87,6 +88,7 @@ ACF.RegisterMissile("227kgGBU", "GBU", {
 		RackModel		= "models/bombs/gbu/gbu12.mdl",
 		MaxLength		= 220,
 		Armor			= 10,
+		ProjLength		= 180,
 		PropLength		= 0,
 		Thrust			= 1,       -- in kg*in/s^2
 		FuelConsumption = 0.1,     -- in g/s/f
@@ -96,7 +98,7 @@ ACF.RegisterMissile("227kgGBU", "GBU", {
 		FinMul			= 0.15,
 		GLimit          = 3,
 		TailFinMul		= 0.5,
-		PenMul			= math.sqrt(0.2),
+		PenMul			= 1,
 		ActualLength 	= 327,
 		ActualWidth		= 27.3
 	},
@@ -144,6 +146,7 @@ ACF.RegisterMissile("454kgGBU", "GBU", {
 		RackModel		= "models/bombs/gbu/gbu16.mdl",
 		MaxLength		= 250,
 		Armor			= 10,
+		ProjLength		= 210,
 		PropLength		= 0,
 		Thrust			= 1,       -- in kg*in/s^2
 		FuelConsumption = 0.1,     -- in g/s/f
@@ -153,7 +156,7 @@ ACF.RegisterMissile("454kgGBU", "GBU", {
 		FinMul			= 0.3,
 		GLimit          = 3,
 		TailFinMul		= 2,
-		PenMul			= math.sqrt(0.2),
+		PenMul			= 1,
 		ActualLength 	= 370,
 		ActualWidth		= 36
 	},
@@ -201,6 +204,7 @@ ACF.RegisterMissile("909kgGBU", "GBU", {
 		RackModel		= "models/bombs/gbu/gbu10.mdl",
 		MaxLength		= 320,
 		Armor			= 10,
+		ProjLength		= 260,
 		PropLength		= 0,
 		Thrust			= 1,       -- in kg*in/s^2
 		FuelConsumption = 0.1,     -- in g/s/f
@@ -210,7 +214,7 @@ ACF.RegisterMissile("909kgGBU", "GBU", {
 		FinMul			= 0.5,
 		GLimit          = 3,
 		TailFinMul		= 4,
-		PenMul			= math.sqrt(0.2),
+		PenMul			= 1,
 		ActualLength 	= 434,
 		ActualWidth		= 46
 	},

--- a/lua/acf/shared/missiles/sam.lua
+++ b/lua/acf/shared/missiles/sam.lua
@@ -19,23 +19,24 @@ ACF.RegisterMissile("FIM-92 SAM", "SAM", {
 	ReloadTime	= 10,
 	Racks		= { ["1x FIM-92"] = true, ["2x FIM-92"] = true, ["4x FIM-92"] = true },
 	Guidance	= { Dumb = true, Infrared = true, ["Anti-missile"] = true },
-	Navigation  = "APN",
+	Navigation  = "PN",
 	Fuzes		= { Contact = true, Radio = true },
 	SeekCone	= 7.5,
 	ViewCone	= 30,
-	Agility		= 0.00023,
+	Agility		= 0.0002,
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/fim_92.mdl",
 		RackModel		= "models/missiles/fim_92_folded.mdl",
 		MaxLength		= 152,
 		Armor			= 5,
-		PropLength		= 85,
-		Thrust			= 100000,	-- in kg*in/s^2
-		FuelConsumption = 0.03,		-- in g/s/f
+		ProjLength		= 60,
+		PropLength		= 80,
+		Thrust			= 200000,	-- in kg*in/s^2
+		FuelConsumption = 0.012,    -- in g/s/f
 		StarterPercent	= 0.1,
 		MaxAgilitySpeed = 200,      -- in m/s
-		DragCoef		= 0.003,
+		DragCoef		= 0.0015,
 		FinMul			= 0.03,
 		GLimit          = 20,
 		TailFinMul		= 0.001,
@@ -63,16 +64,17 @@ ACF.RegisterMissile("Strela-1 SAM", "SAM", {
 	Fuzes		= { Contact = true, Radio = true },
 	SeekCone	= 20,
 	ViewCone	= 40,
-	Agility		= 0.001,
+	Agility		= 0.0006,
 	ArmDelay	= 0.2,
 	Round = {
 		Model			= "models/missiles/9m31.mdl",
 		RackModel		= "models/missiles/9m31f.mdl",
 		MaxLength		= 180,
 		Armor			= 5,
+		ProjLength		= 60,
 		PropLength		= 100,
-		Thrust			= 400000,	-- in kg*in/s^2
-		FuelConsumption = 0.025,	-- in g/s/f
+		Thrust			= 800000,	-- in kg*in/s^2
+		FuelConsumption = 0.018,	-- in g/s/f
 		StarterPercent	= 0.1,
 		MaxAgilitySpeed = 300,      -- in m/s
 		DragCoef		= 0.003,

--- a/lua/acf/shared/missiles/uar.lua
+++ b/lua/acf/shared/missiles/uar.lua
@@ -42,16 +42,17 @@ ACF.RegisterMissile("RS82 ASR", "UAR", {
 		Model			= "models/missiles/rs82.mdl",
 		MaxLength		= 60,
 		Armor			= 5,
+		ProjLength		= 25,
 		PropLength		= 35,
-		Thrust			= 40000,    -- in kg*in/s^2
-		FuelConsumption = 0.08,     -- in g/s/f
+		Thrust			= 50000,    -- in kg*in/s^2
+		FuelConsumption = 0.033,    -- in g/s/f
 		StarterPercent	= 0.15,
 		MaxAgilitySpeed = 1,        -- in m/s
 		DragCoef		= 0.001,
 		FinMul			= 0.01,
 		GLimit          = 1,
 		TailFinMul		= 0.05,
-		PenMul			= math.sqrt(2),
+		PenMul			= 0.8,
 		ActualLength 	= 60,
 		ActualWidth		= 8.2
 	},
@@ -82,16 +83,17 @@ ACF.RegisterMissile("HVAR ASR", "UAR", {
 		RackModel		= "models/missiles/hvar_folded.mdl",
 		MaxLength		= 173,
 		Armor			= 5,
+		ProjLength		= 78,
 		PropLength		= 95,
-		Thrust			= 270000,   -- in kg*in/s^2
-		FuelConsumption = 0.053,    -- in g/s/f
+		Thrust			= 800000,   -- in kg*in/s^2
+		FuelConsumption = 0.016,    -- in g/s/f
 		StarterPercent	= 0.15,
 		MaxAgilitySpeed = 1,        -- in m/s
 		DragCoef		= 0.005,
 		FinMul			= 0.01,
 		GLimit          = 1,
 		TailFinMul		= 0.075,
-		PenMul			= math.sqrt(1),
+		PenMul			= 0.65,
 		ActualLength 	= 173,
 		ActualWidth		= 12.7
 	},
@@ -120,16 +122,17 @@ ACF.RegisterMissile("SPG-9 ASR", "UAR", {
 		RackModel		= "models/munitions/round_100mm_mortar_shot.mdl",
 		MaxLength		= 100,
 		Armor			= 5,
+		ProjLength		= 45,
 		PropLength		= 55,
-		Thrust			= 300000,   -- in kg*in/s^2
-		FuelConsumption = 0.019,    -- in g/s/f
-		StarterPercent	= 0.95,
+		Thrust			= 200000,   -- in kg*in/s^2
+		FuelConsumption = 0.012,    -- in g/s/f
+		StarterPercent	= 0.6,
 		MaxAgilitySpeed = 1,        -- in m/s
-		DragCoef		= 0.005,
+		DragCoef		= 0.001,
 		FinMul			= 0.002,
 		GLimit          = 1,
 		TailFinMul		= 0.02,
-		PenMul			= math.sqrt(3),
+		PenMul			= 1.32,
 		ActualLength 	= 100,
 		ActualWidth		= 7.3
 	},
@@ -159,16 +162,17 @@ ACF.RegisterMissile("S-24 ASR", "UAR", {
 		Model			= "models/missiles/s24.mdl",
 		MaxLength		= 233,
 		Armor			= 5,
+		ProjLength		= 103,
 		PropLength		= 130,
 		Thrust			= 2000000,  -- in kg*in/s^2
-		FuelConsumption = 0.052,    -- in g/s/f
+		FuelConsumption = 0.02,    -- in g/s/f
 		StarterPercent	= 0.15,
 		MaxAgilitySpeed = 1,        -- in m/s
 		DragCoef		= 0.01,
 		FinMul			= 0.1,
 		GLimit          = 1,
 		TailFinMul		= 0.3,
-		PenMul			= math.sqrt(1.5),
+		PenMul			= 1.05,
 		ActualLength 	= 233,
 		ActualWidth		= 24
 	},
@@ -197,8 +201,9 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 		RackModel		= "models/missiles/RW61M.mdl",
 		MaxLength		= 150,
 		Armor			= 5,
-		PropLength		= 85,
-		Thrust			= 500000,   -- in kg*in/s^2
+		ProjLength		= 60,
+		PropLength		= 90,
+		Thrust			= 700000,   -- in kg*in/s^2
 		FuelConsumption = 0.048,    -- in g/s/f
 		StarterPercent	= 0.2,
 		MaxAgilitySpeed = 1,        -- in m/s
@@ -206,7 +211,7 @@ ACF.RegisterMissile("RW61 ASR", "UAR", {
 		FinMul			= 0,
 		GLimit          = 1,
 		TailFinMul		= 10,
-		PenMul			= math.sqrt(1),
+		PenMul			= 1.2,
 		ActualLength 	= 150,
 		ActualWidth		= 38
 	},


### PR DESCRIPTION
Missiles get a maximum projectile length, limiting it just like the propellant. 

"Empty" space (things that are neither warhead nor propellant, like guidance, gyros, etc.) in the missiles can now be modeled, and missiles were balanced to reflect some internal space being empty. Approximate real world lengths were used where possible.

Penetration multipliers were balanced across the board to use real world values. You can no longer go over this maximum penetration by over-sizing the warhead, as that is no longer possible.