### PR TITLE
Rebalanced missile speed and agility

### DIFF
--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -219,8 +219,8 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		Armor			= 5,
 		ProjLength		= 40,
 		PropLength		= 50,
-		Thrust			= 90000,   -- in kg*in/s^2
-		FuelConsumption = 0.04,    -- in g/s/f
+		Thrust			= 180000,   -- in kg*in/s^2
+		FuelConsumption = 0.032,    -- in g/s/f
 		StarterPercent	= 0.15,
 		MaxAgilitySpeed = 200,      -- in m/s
 		DragCoef		= 0.013,

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -23,7 +23,7 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 	Guidance	= { Dumb = true, ["Wire (MCLOS)"] = true, ["Wire (SACLOS)"] = true },
 	Fuzes		= { Contact = true, Optical = true },
 	SkinIndex	= { HEAT = 0, HE = 1 },
-	Agility		= 0.00022,
+	Agility		= 0.0006,
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/at3.mdl",
@@ -31,11 +31,11 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 		Armor			= 5,
 		ProjLength		= 30,
 		PropLength		= 45,
-		Thrust			= 4000,     -- in kg*in/s^2
+		Thrust			= 3020,     -- in kg*in/s^2
 		FuelConsumption = 0.05,     -- in g/s/f
-		StarterPercent	= 0.45,
+		StarterPercent	= 0.61,
 		MaxAgilitySpeed = 70,       -- in m/s
-		DragCoef		= 0.01,
+		DragCoef		= 0.0112,
 		FinMul			= 0.1,
 		GLimit          = 10,
 		TailFinMul		= 0.01,
@@ -62,7 +62,7 @@ ACF.RegisterMissile("BGM-71E ASM", "ATGM", {
 	Guidance	= { Dumb = true, ["Wire (SACLOS)"] = true },
 	Navigation  = "PN",
 	Fuzes		= { Contact = true, Optical = true },
-	Agility		= 0.00018,
+	Agility		= 0.00024,
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/bgm_71e.mdl",
@@ -96,14 +96,14 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 	Mass		= 49,
 	Diameter	= 6.5 * 25.4, -- in mm
 	Year		= 1984,
-	ReloadTime	= 25,
+	ReloadTime	= 30,
 	Racks		= { ["1xRK"] = true, ["2x AGM-114"] = true, ["4x AGM-114"] = true },
 	Guidance	= { Dumb = true, Laser = true, ["Active Radar"] = true },
 	Navigation  = "PN",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 40,
 	SeekCone	= 10,
-	Agility		= 0.0005,
+	Agility		= 0.0008,
 	ArmDelay	= 0.5,
 	Bodygroups = {
 		guidance = {
@@ -130,7 +130,7 @@ ACF.RegisterMissile("AGM-114 ASM", "ATGM", {
 		MaxAgilitySpeed = 100,      -- in m/s
 		DragCoef		= 0.005,
 		FinMul			= 0.1,
-		GLimit          = 10,
+		GLimit          = 14,
 		TailFinMul		= 0.01,
 		PenMul			= 3.22,
 		ActualLength 	= 160,
@@ -151,13 +151,13 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 	Mass		= 50,
 	Diameter	= 10.9 * 25.4, -- in mm
 	Year		= 1984,
-	ReloadTime	= 20,
+	ReloadTime	= 25,
 	Racks		= { ["1x Ataka"] = true, ["1xRK"] = true, ["2xRK"] = true, ["4xRK"] = true },
 	Guidance	= { Dumb = true, ["Radio (SACLOS)"] = true },
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 45,
-	Agility		= 0.0003,
+	Agility		= 0.00072,
 	ArmDelay	= 0.1,
 	NoDamage    = true,
 	Round = {
@@ -167,13 +167,13 @@ ACF.RegisterMissile("Ataka ASM", "ATGM", {
 		Armor			= 5,
 		ProjLength		= 50,
 		PropLength		= 100,
-		Thrust			= 800000,   -- in kg*in/s^2
-		FuelConsumption = 0.03,    -- in g/s/f
-		StarterPercent	= 0.02,
+		Thrust			= 700000,   -- in kg*in/s^2
+		FuelConsumption = 0.022,    -- in g/s/f
+		StarterPercent	= 0.05,
 		MaxAgilitySpeed = 200,      -- in m/s
-		DragCoef		= 0.002,
+		DragCoef		= 0.024,
 		FinMul			= 0.1,
-		GLimit          = 10,
+		GLimit          = 13.8,
 		TailFinMul		= 0.01,
 		PenMul			= 3.09,
 		ActualLength 	= 183,
@@ -200,7 +200,7 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 20,
-	Agility		= 0.0002,
+	Agility		= 0.00077,
 	ArmDelay	= 0.1,
 	Bodygroups = {
 		fins = {
@@ -252,7 +252,7 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 90,
-	Agility		= 0.0006,
+	Agility		= 0.00014,
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/at2.mdl",
@@ -260,9 +260,9 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 		Armor			= 5,
 		ProjLength		= 35,
 		PropLength		= 35,
-		Thrust			= 10000,    -- in kg*in/s^2
+		Thrust			= 6000,    -- in kg*in/s^2
 		FuelConsumption = 0.035,    -- in g/s/f
-		StarterPercent	= 0.50,
+		StarterPercent	= 0.7,
 		MaxAgilitySpeed = 100,      -- in m/s
 		DragCoef		= 0.015,
 		FinMul			= 0.1,

--- a/lua/acf/shared/missiles/asm.lua
+++ b/lua/acf/shared/missiles/asm.lua
@@ -23,7 +23,7 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 	Guidance	= { Dumb = true, ["Wire (MCLOS)"] = true, ["Wire (SACLOS)"] = true },
 	Fuzes		= { Contact = true, Optical = true },
 	SkinIndex	= { HEAT = 0, HE = 1 },
-	Agility		= 0.0006,
+	Agility		= 0.0005,
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/at3.mdl",
@@ -31,11 +31,11 @@ ACF.RegisterMissile("AT-3 ASM", "ATGM", {
 		Armor			= 5,
 		ProjLength		= 30,
 		PropLength		= 45,
-		Thrust			= 3020,     -- in kg*in/s^2
+		Thrust			= 8020,     -- in kg*in/s^2
 		FuelConsumption = 0.05,     -- in g/s/f
-		StarterPercent	= 0.61,
-		MaxAgilitySpeed = 70,       -- in m/s
-		DragCoef		= 0.0112,
+		StarterPercent	= 0.12,
+		MaxAgilitySpeed = 100,       -- in m/s
+		DragCoef		= 0.02,
 		FinMul			= 0.1,
 		GLimit          = 10,
 		TailFinMul		= 0.01,
@@ -200,7 +200,7 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 20,
-	Agility		= 0.00077,
+	Agility		= 0.0004,
 	ArmDelay	= 0.1,
 	Bodygroups = {
 		fins = {
@@ -219,11 +219,11 @@ ACF.RegisterMissile("9M113 ASM", "ATGM", {
 		Armor			= 5,
 		ProjLength		= 40,
 		PropLength		= 50,
-		Thrust			= 430000,   -- in kg*in/s^2
-		FuelConsumption = 0.030,    -- in g/s/f
-		StarterPercent	= 0.1,
+		Thrust			= 90000,   -- in kg*in/s^2
+		FuelConsumption = 0.04,    -- in g/s/f
+		StarterPercent	= 0.15,
 		MaxAgilitySpeed = 200,      -- in m/s
-		DragCoef		= 0.005,
+		DragCoef		= 0.013,
 		FinMul			= 0.1,
 		GLimit          = 8,
 		TailFinMul		= 0.01,
@@ -252,7 +252,7 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true },
 	ViewCone	= 90,
-	Agility		= 0.00014,
+	Agility		= 0.00008,
 	ArmDelay	= 0.1,
 	Round = {
 		Model			= "models/missiles/at2.mdl",
@@ -260,11 +260,11 @@ ACF.RegisterMissile("AT-2 ASM", "ATGM", {
 		Armor			= 5,
 		ProjLength		= 35,
 		PropLength		= 35,
-		Thrust			= 6000,    -- in kg*in/s^2
+		Thrust			= 120000,    -- in kg*in/s^2
 		FuelConsumption = 0.035,    -- in g/s/f
-		StarterPercent	= 0.7,
-		MaxAgilitySpeed = 100,      -- in m/s
-		DragCoef		= 0.015,
+		StarterPercent	= 0.08,
+		MaxAgilitySpeed = 200,      -- in m/s
+		DragCoef		= 0.005,
 		FinMul			= 0.1,
 		GLimit          = 10,
 		TailFinMul		= 0.01,


### PR DESCRIPTION
Missiles have been rebalanced to reflect their roles better and act closer to their real world counterparts
### NATO
**BGM-71E**
- Agility substantially increased in order to better suit it's role
- Peak speed decreaed from 280m/s to 278m/s, sustain increased from 200-240m/s to 270m/s
- 
**AGM-114**
- Agility increased in order to allow for the ability to do "Hi-LOBL/LOAL"
- G limit increased to 14 accordingly
- Reload time increased from 25 to 30

### USSR
**9M14**
- Increased agility so it's usable outside of 700m
- Rail start speed decreased from 84m/s to 32m/s

**9M17**
- Reduced agility to match description
- Boost motor time reduced to 1.13s
- Peak speed increased from 145m/s to 212m/s

**9M120**
- Agility increased to make it feasible on GMod maps
- G limit raised to 13.5
- Peak speed increased from 352m/s to 459m/s
- Reload increased as it has much superior speed to BGM-71E

**9M133**
- Agility increased substantially to better fit it's role as a TOW equivalent
- Peak speed decreased from 291m/s to 265m/s