### PR TITLE
Fixed missile thrust inconsistency

### DIFF
--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -222,19 +222,20 @@ local function CalcFlight(Missile)
 	Dir = DirAng:Forward()
 	Missile.RotAxis = Missile.RotAxis * (1 - 0.7 * DeltaTime)
 
+	local FuelMod = math.Clamp(Missile.MotorLength / DeltaTime, 0, 1)
 	if Missile.MotorEnabled then
-		Missile.MotorLength = Missile.MotorLength - DeltaTime
-
-		-- Update the missile's mass and inertia according to the remaining fuel
-		Missile.Mass = Missile.ProjMass + Missile.PropMass * math.max(Missile.MotorLength / Missile.MaxMotorLength, 0)
-		Missile.Inertia	= Missile.AreaOfInertia * Missile.Mass
-
 		if Missile.MotorLength <= 0 then
 			SetMotorState(Missile, false)
+		else
+			Missile.MotorLength = math.max(Missile.MotorLength - DeltaTime, 0)
+
+			-- Update the missile's mass and inertia according to the remaining fuel
+			Missile.Mass = Missile.ProjMass + Missile.PropMass * Missile.MotorLength / Missile.MaxMotorLength
+			Missile.Inertia	= Missile.AreaOfInertia * Missile.Mass
 		end
 	end
 
-	local Thrust    = Dir * Missile.Thrust / Missile.Mass
+	local Thrust    = Dir * FuelMod * Missile.Thrust / Missile.Mass
 	local Up        = Dir:Cross(LastVel):Cross(Dir):GetNormalized()
 	local DotSimple = Up.x * VelNorm.x + Up.y * VelNorm.y + Up.z * VelNorm.z
 	local Lift      = -Up * DotSimple * LiftMultiplier


### PR DESCRIPTION
Previously, missiles checked if their fuel was expended, and cutoff the thrust immediately if so. This induces some dependency on the tick rate, but it was most noticeable with missiles with very short burn times, as the motor could cut off before thrust was applied in the first place.

This fixes that issue, the motor is only cut off during the following tick, and the thrust is scaled back if there is not enough fuel to burn for the entire duration of the last tick. From my testing, thrust is now consistent, and missiles with very little propellant all leave with the same velocity, instead of some going fast and some immediately dropping.