### PR TITLE
Fix HEAT missile destruction behavior

### DIFF
--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -691,7 +691,6 @@ function ENT:ACF_OnDamage(Bullet, Trace)
 
 			self:SetNW2String("AmmoType", "HE")
 			end
-		
 			DetonateMissile(self, Owner)
 
 			return HitRes

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -686,6 +686,12 @@ function ENT:ACF_OnDamage(Bullet, Trace)
 
 		-- We give it a chance to explode when it gets penetrated aswell.
 		if math.random() > 0.75 * Ratio then
+			if BulletData.Type == "HEAT" then
+			BulletData.Type = "HE"
+
+			self:SetNW2String("AmmoType", "HE")
+			end
+		
 			DetonateMissile(self, Owner)
 
 			return HitRes
@@ -703,8 +709,9 @@ function ENT:ACF_OnDamage(Bullet, Trace)
 			self.UseGuidance = nil
 		end
 
-		-- Damaged the liner.
-		if BulletData.Type == "HEAT" and math.random() > 0.9 * Ratio then
+		-- Any Damage to the liner.
+		-- For sake of consistency and reducing of RNG on damage
+		if BulletData.Type == "HEAT" and 0.95 > Ratio then
 			BulletData.Type = "HE"
 
 			self:SetNW2String("AmmoType", "HE")


### PR DESCRIPTION
Fix HEAT Missile launching ACF projectile when destroyed.
Fix Liner damage behavior to be more consistent and not dependent on RNG