### PR TITLE
GLATGM Command link removal, replaced with variable velocity

### DIFF
--- a/lua/acf/shared/ammo_types/glatgm.lua
+++ b/lua/acf/shared/ammo_types/glatgm.lua
@@ -48,12 +48,12 @@ if SERVER then
 	function Ammo:GetCrateText(BulletData)
 		local Text = "Peak Velocity: %s m/s\nLaunch Velocity: %s m/s\nAcceleration: %s s\nMax Penetration: %s mm\nBlast Radius: %s m\nBlast Energy: %s KJ"
 		local Data = self:GetDisplayData(BulletData)
-		
+
 		local MV = math.Clamp(BulletData.MuzzleVel / ACF.Scale, 200, 1600) -- Minimum initial launch velocity of 40m/s and lowest peak at 100m/s while top speed is 800m/s
 		local PeakVel = math.Round(MV / 2, 2)
 		local LaunchVel = math.Round(MV / 5, 2)
 		local Accel = math.Round(math.Clamp(BulletData.ProjMass / BulletData.PropMass + BulletData.Caliber / 7, 0.2, 10), 2)
-		
+
 		return Text:format(PeakVel, LaunchVel, Accel,  math.floor(Data.MaxPen), math.Round(Data.BlastRadius, 2), math.floor(BulletData.BoomFillerMass * ACF.HEPower))
 	end
 
@@ -161,7 +161,7 @@ else
 			self:UpdateRoundData(ToolData, BulletData)
 
 			local Text		= "Peak Velocity: %s m/s\nLaunch Velocity: %s m/s\nAcceleration: %s s\nProjectile Mass : %s\nPropellant Mass : %s\nExplosive Mass : %s"
-			
+
 			local MV = math.Clamp(BulletData.MuzzleVel / ACF.Scale, 200, 1600) -- Minimum initial launch velocity of 40m/s and lowest peak at 100m/s while top speed is 800m/s
 			local PeakVel	= math.Round(MV / 2, 2)
 			local LaunchVel = math.Round(MV / 5, 2)

--- a/lua/acf/shared/ammo_types/glatgm.lua
+++ b/lua/acf/shared/ammo_types/glatgm.lua
@@ -31,6 +31,8 @@ function Ammo:BaseConvert(ToolData)
 end
 
 if SERVER then
+	local CrateText = "Peak Velocity: %s m/s\nLaunch Velocity: %s m/s\nAcceleration: %s s\nMax Penetration: %s mm\nBlast Radius: %s m\nBlast Energy: %s KJ"
+
 	function Ammo:Create(Gun, BulletData)
 		if Gun:GetClass() == "acf_ammo" then
 			ACF.CreateBullet(BulletData)
@@ -46,15 +48,13 @@ if SERVER then
 	end
 
 	function Ammo:GetCrateText(BulletData)
-		local Text = "Peak Velocity: %s m/s\nLaunch Velocity: %s m/s\nAcceleration: %s s\nMax Penetration: %s mm\nBlast Radius: %s m\nBlast Energy: %s KJ"
-		local Data = self:GetDisplayData(BulletData)
+		local Data      = self:GetDisplayData(BulletData)
+		local Velocity  = math.Clamp(BulletData.MuzzleVel / ACF.Scale, 200, 1600) -- Minimum initial launch velocity of 40m/s and lowest peak at 100m/s while top speed is 800m/s
+		local PeakVel   = math.Round(Velocity * 0.5, 2)
+		local LaunchVel = math.Round(Velocity * 0.2, 2)
+		local Accel     = math.Round(math.Clamp(BulletData.ProjMass / BulletData.PropMass + BulletData.Caliber / 7, 0.2, 10), 2)
 
-		local MV = math.Clamp(BulletData.MuzzleVel / ACF.Scale, 200, 1600) -- Minimum initial launch velocity of 40m/s and lowest peak at 100m/s while top speed is 800m/s
-		local PeakVel = math.Round(MV / 2, 2)
-		local LaunchVel = math.Round(MV / 5, 2)
-		local Accel = math.Round(math.Clamp(BulletData.ProjMass / BulletData.PropMass + BulletData.Caliber / 7, 0.2, 10), 2)
-
-		return Text:format(PeakVel, LaunchVel, Accel,  math.floor(Data.MaxPen), math.Round(Data.BlastRadius, 2), math.floor(BulletData.BoomFillerMass * ACF.HEPower))
+		return CrateText:format(PeakVel, LaunchVel, Accel,  math.floor(Data.MaxPen), math.Round(Data.BlastRadius, 2), math.floor(BulletData.BoomFillerMass * ACF.HEPower))
 	end
 
 	function Ammo:HEATExplosionEffect(Bullet, Pos)
@@ -161,11 +161,10 @@ else
 			self:UpdateRoundData(ToolData, BulletData)
 
 			local Text		= "Peak Velocity: %s m/s\nLaunch Velocity: %s m/s\nAcceleration: %s s\nProjectile Mass : %s\nPropellant Mass : %s\nExplosive Mass : %s"
-
-			local MV = math.Clamp(BulletData.MuzzleVel / ACF.Scale, 200, 1600) -- Minimum initial launch velocity of 40m/s and lowest peak at 100m/s while top speed is 800m/s
-			local PeakVel	= math.Round(MV / 2, 2)
-			local LaunchVel = math.Round(MV / 5, 2)
-			local Accel = math.Round(math.Clamp(BulletData.ProjMass / BulletData.PropMass + BulletData.Caliber / 7, 0.2, 10), 2)
+			local Velocity  = math.Clamp(BulletData.MuzzleVel / ACF.Scale, 200, 1600) -- Minimum initial launch velocity of 40m/s and lowest peak at 100m/s while top speed is 800m/s
+			local PeakVel	= math.Round(Velocity * 0.5, 2)
+			local LaunchVel = math.Round(Velocity * 0.2, 2)
+			local Accel     = math.Round(math.Clamp(BulletData.ProjMass / BulletData.PropMass + BulletData.Caliber / 7, 0.2, 10), 2)
 			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
 			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
 			local Filler	= ACF.GetProperMass(BulletData.FillerMass)

--- a/lua/acf/shared/ammo_types/glatgm.lua
+++ b/lua/acf/shared/ammo_types/glatgm.lua
@@ -167,7 +167,6 @@ else
 			local LaunchVel = math.Round(MV / 5, 2)
 			local Accel = math.Round(math.Clamp(BulletData.ProjMass / BulletData.PropMass + BulletData.Caliber / 7, 0.2, 10), 2)
 			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			print(BulletData.ProjMass)
 			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
 			local Filler	= ACF.GetProperMass(BulletData.FillerMass)
 

--- a/lua/entities/acf_glatgm/init.lua
+++ b/lua/entities/acf_glatgm/init.lua
@@ -212,7 +212,7 @@ function ENT:Think()
 	local IsDelayed = self.GuideDelay > Time
 	local Computer  = self:GetComputer()
 	local Position  = self.Position
-	
+
 	self.Speed = self.LaunchVel + self.DiffVel * math.Clamp(1 - (self.AccelTime - Time) / self.AccelLength, 0, 1)
 
 	if not IsDelayed and IsValid(Computer) then

--- a/lua/entities/acf_glatgm/init.lua
+++ b/lua/entities/acf_glatgm/init.lua
@@ -31,8 +31,9 @@ function MakeACF_GLATGM(Gun, BulletData)
 
 	if not IsValid(Entity) then return end
 
-	local Caliber = BulletData.Caliber * 10
-	local Owner   = Gun.Owner
+	local Velocity = math.Clamp(BulletData.MuzzleVel / ACF.Scale, 200, 1600)
+	local Caliber  = BulletData.Caliber * 10
+	local Owner    = Gun.Owner
 
 	Entity:SetAngles(Gun:GetAngles())
 	Entity:SetPos(BulletData.Pos)
@@ -73,11 +74,10 @@ function MakeACF_GLATGM(Gun, BulletData)
 	Entity.Filter       = Entity.BulletData.Filter
 	Entity.Agility      = 50 -- Magic multiplier that controls the agility of the missile
 	Entity.IsSubcaliber = Caliber < 100
-	local MV = math.Clamp(BulletData.MuzzleVel / ACF.Scale, 200, 1600)
-	Entity.LaunchVel = math.Round(MV / 5, 2) * 39.37
-	Entity.DiffVel = math.Round(MV / 2, 2) * 39.37 - Entity.LaunchVel
+	Entity.LaunchVel    = math.Round(Velocity * 0.2, 2) * 39.37
+	Entity.DiffVel      = math.Round(Velocity * 0.5, 2) * 39.37 - Entity.LaunchVel
 	Entity.AccelLength  = math.Round(math.Clamp(BulletData.ProjMass / BulletData.PropMass + BulletData.Caliber / 7, 0.2, 10), 2)
-	Entity.AccelTime = Entity.LastThink + Entity.AccelLength
+	Entity.AccelTime    = Entity.LastThink + Entity.AccelLength
 	Entity.Speed        = Entity.LaunchVel
 	Entity.SpiralRadius = Entity.IsSubcaliber and 3.5 or nil
 	Entity.SpiralSpeed  = Entity.IsSubcaliber and 15 or nil
@@ -211,34 +211,30 @@ function ENT:Think()
 	local DeltaTime = ACF.CurTime - self.LastThink
 	local IsDelayed = self.GuideDelay > Time
 	local Computer  = self:GetComputer()
+	local CanSee    = IsValid(Computer) and CheckViewCone(self, Computer.HitPos)
 	local Position  = self.Position
 
 	self.Speed = self.LaunchVel + self.DiffVel * math.Clamp(1 - (self.AccelTime - Time) / self.AccelLength, 0, 1)
 
-	if not IsDelayed and IsValid(Computer) then
-		local StartPos = Computer:LocalToWorld(Computer.Offset or Vector(6, -1, 0))
-		local HitPos   = Computer.HitPos
-		local CanSee   = CheckViewCone(self, HitPos)
+	if not IsDelayed and CanSee then
+		local Agility            = self.Agility
+		local AgilityVector      = Vector(self.Speed, Agility, Agility) * DeltaTime
+		local ComputerCorrection = Computer:WorldToLocal(Position)
+		local Desired            = AngleRand() * 0.005
 
-		if CanSee and Position:Distance(StartPos) then
-			local Agility = self.Agility
+		ComputerCorrection = Computer:LocalToWorld(Vector(ComputerCorrection.X + self.Speed * 0.1))
+		Correction         = ClampVec(self:WorldToLocal(ComputerCorrection), -AgilityVector, AgilityVector)
 
-			local AgilityVector = Vector(self.Speed,Agility,Agility) * DeltaTime
-			local ComputerCorrection = Computer:WorldToLocal(Position)
-			ComputerCorrection = Computer:LocalToWorld(Vector(ComputerCorrection.X + self.Speed / 10,0,0))
-			Correction = ClampVec(self:WorldToLocal(ComputerCorrection),-AgilityVector,AgilityVector)
-
-			local Desired = AngleRand() * 0.005
-			if math.abs(Correction.y) + math.abs(Correction.z) >= 0.7 then
-				Desired = self:WorldToLocalAngles((ComputerCorrection - Position):Angle()) + Desired
-			else
-				Desired = self:WorldToLocalAngles(Computer.TraceDir:Angle()) + Desired
-			end
-			Direction  = ClampAng(Desired, -Agility, Agility) * DeltaTime
-
-			IsGuided   = true
-			self.Innacuracy = 0
+		if math.abs(Correction.y) + math.abs(Correction.z) >= 0.7 then
+			Desired = self:WorldToLocalAngles((ComputerCorrection - Position):Angle()) + Desired
+		else
+			Desired = self:WorldToLocalAngles(Computer.TraceDir:Angle()) + Desired
 		end
+
+		Direction = ClampAng(Desired, -Agility, Agility) * DeltaTime
+		IsGuided  = true
+
+		self.Innacuracy = 0
 	end
 
 	if not IsGuided then


### PR DESCRIPTION
Command link was an archaic attempt to balance GLATGM unsuccessfully, it has been replaced by variable velocity with a minimum and max of 40m/s and 800m/s.

Standoff has also been reduced to a ratio of 0.4 from 0.7 to give an advantage to conventional HEATFS

- Subcaliber (below 100mm diameter) speed nerf removed
- Speed adjusted from 127m/s to a scale of 40m/s to 800m/s
- Extra standoff ratio from 0.7 to 0.4