### PR TITLE
Missile Detonate input will cause HEAT to convert to HE

### DIFF
--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -317,6 +317,11 @@ ACF.AddInputAction("acf_missile", "Detonate", function(Entity, Value)
 	if not Entity.Launched then return end
 
 	if Value ~= 0 then
+		local BulletData = Entity.BulletData
+		if BulletData.Type == "HEAT" then
+			BulletData.Type = "HE"
+			Entity:SetNW2String("AmmoType", "HE")
+		end
 		Entity:Detonate(true)
 	end
 end)


### PR DESCRIPTION
As of now it is possible to fly a missile over a target, do the ballistics code for the bullet it will spawn and then detonate it above the target causing it to fall ontop of target in a very unfair manner, this change will convert it to HE instead when using the detonate input.