### PR TITLE
Change ACFM_GhostPeriod to 0.05s

### DIFF
--- a/lua/acf/base/sh_acfm_cvars.lua
+++ b/lua/acf/base/sh_acfm_cvars.lua
@@ -15,7 +15,7 @@ elseif SERVER then
 
 	-- Should missiles ignore impacts for a duration after they're launched?
 	-- Set to 0 to disable, or set to a number of seconds that missiles should "ghost" through entities.
-	CreateConVar("ACFM_GhostPeriod", 0.1, FCVAR_ARCHIVE + FCVAR_NOTIFY)
+	CreateConVar("ACFM_GhostPeriod", 0.05, FCVAR_ARCHIVE + FCVAR_NOTIFY)
 
 	CreateConVar("sbox_max_acf_explosive", 20, FCVAR_ARCHIVE + FCVAR_NOTIFY)
 end


### PR DESCRIPTION
The old default of 0.1s isn't very realistic and can make some missiles unfun to use.
A lot of missiles with a ghost period of 0.1s tend to ghost for about 10~ meters.