### PR TITLE
Return early on invalid data

### DIFF
--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -234,6 +234,8 @@ do -- Spawning and Updating --------------------
 		VerifyData(Data)
 
 		local Rack    = Racks[Data.Rack]
+		if not Rack then return false, "Invalid rack type!" end
+
 		local OldData = self.RackData
 
 		if OldData.OnLast then


### PR DESCRIPTION
Should fix:
```
addons/acf-3-missiles/lua/entities/acf_rack/init.lua:63: attempt to index local 'Rack' (a nil value)
   1.  __index - [C]:-1
    2.  UpdateRack - addons/acf-3-missiles/lua/entities/acf_rack/init.lua:63
     3.  Update - addons/acf-3-missiles/lua/entities/acf_rack/init.lua:247
      4.  Update - addons/acf-3/lua/acf/core/classes/entities/registration.lua:131
       5.  LeftClick - addons/acf-3/lua/acf/menu/tool_functions.lua:432
        6.  unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:220
```
Didn't test the code, but i don't see harm in this.