### PR TITLE
Add spawn hook for missiles

### DIFF
--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -404,6 +404,8 @@ function MakeACF_Missile(Player, Pos, Ang, Rack, MountPoint, Crate)
 	Missile.Inputs          = WireLib.CreateInputs(Missile, Inputs)
 	Missile.Outputs         = WireLib.CreateOutputs(Missile, Outputs)
 
+	HookRun("ACF_OnEntitySpawn", "acf_missile", Missile, Data, Class, Crate)
+
 	WireLib.TriggerOutput(Missile, "Entity", Missile)
 
 	Missile:UpdateModel(Missile.RackModel or Missile.RealModel)


### PR DESCRIPTION
The missiles were missing an `ACF_OnEntitySpawn`.

Notably, none of the ACF-3-Missiles entities have an `ACF_PreEntitySpawn` hook. If those would be acceptable, I can add them in a new PR 👍 