### PR TITLE
FFWD dev to master, added warning receivers (laser/radar)

### DIFF
--- a/lua/acf/entities/components/computers.lua
+++ b/lua/acf/entities/components/computers.lua
@@ -510,6 +510,7 @@ do -- Laser guidance computer
 		OnUpdate = function(Entity, _, _, Computer)
 			Entity.IsComputer = true
 			Entity.Lasing     = false
+			Entity.Offset     = Computer.Offset
 			Entity.OnCooldown = false
 			Entity.HitPos     = Vector()
 			Entity.Distance   = 0

--- a/lua/acf/entities/sensors/receiver_menu_cl.lua
+++ b/lua/acf/entities/sensors/receiver_menu_cl.lua
@@ -1,0 +1,9 @@
+local ACF  = ACF
+local Text = "Mass : %s kg\n"
+
+function ACF.CreateReceiverMenu(Data, Menu)
+
+	Menu:AddLabel(Text:format(Data.Mass))
+
+	ACF.SetClientData("PrimaryClass", "acf_receiver")
+end

--- a/lua/acf/entities/sensors/receivers/receivers.lua
+++ b/lua/acf/entities/sensors/receivers/receivers.lua
@@ -1,0 +1,139 @@
+local ACF     = ACF
+local Sensors = ACF.Classes.Sensors
+local TraceLine	  = util.TraceLine
+
+Sensors.Register("WARN-Receiver", {
+	Name		= "Warning Receiver",
+	Entity		= "acf_receiver",
+	CreateMenu	= ACF.CreateReceiverMenu,
+	LimitConVar	= {
+		Name = "_acf_receiver",
+		Amount = 4,
+		Text = "Maximum amount of ACF receivers a player can create."
+	},
+})
+
+do -- Laser Receiver
+	local function ReceiveSource(Receiver)
+		local Lasers = {}
+
+		local ReceiverOrigin = Receiver:LocalToWorld(Receiver.Origin)
+
+		for k,v in pairs(ACF.ActiveLasers) do
+			local Dir = k.Dir or k:GetForward()
+			if v.Distance > 0 then Dir = (v.HitPos - v.Origin):GetNormalized() end
+
+			if Dir:Dot((ReceiverOrigin - v.Origin):GetNormalized()) >= Receiver.Cone then Lasers[k] = true end
+		end
+
+		-- Wiremod laser pointer, because it's, you know, a laser
+		for _,ply in pairs(player.GetAll()) do
+			local Wep = ply:GetWeapon("laserpointer")
+			if not IsValid(Wep) then continue end
+
+			if Wep.Pointing then
+				local Las = {Dir = ply:EyeAngles():Forward(),Position = ply:EyePos(),Player = ply}
+
+				if Las.Dir:Dot((ReceiverOrigin - Las.Position):GetNormalized()) >= Receiver.Cone then Lasers[Las] = true end
+			end
+		end
+
+		return Lasers
+	end
+
+	local TraceData	  = { start = true, endpos = true, mask = MASK_SOLID }
+	local function CheckLOS(Receiver, Source, Start, End)
+		TraceData.start = Start
+		TraceData.endpos = End
+		if IsValid(Source.Player) then
+			TraceData.filter = {Receiver,Source.Player}
+		else TraceData.filter = {Receiver,Source} end
+
+		return not TraceLine(TraceData).Hit
+	end
+
+	Sensors.RegisterItem("LAS-Receiver", "WARN-Receiver", {
+		Name		= "Laser Warning Receiver",
+		Description	= "An optical unit designed to detect laser sources and give a precise direction.",
+		Model		= "models/jaanus/wiretool/wiretool_range.mdl",
+
+		Mass		= 25,
+		Health		= 10,
+		Armor		= 10,
+		Offset 		= Vector(0,0,3),
+
+		ThinkDelay	= 0.25,
+		Divisor		= 2.5, -- Divisor (pre-floor) and then multiplier to give a choppy angle
+		Cone		= math.cos(2.5 / 90),
+
+		Detect		= ReceiveSource,
+		CheckLOS	= CheckLOS,
+
+		Preview = {
+			FOV = 145,
+		},
+	})
+end
+
+do -- Radar Receiver
+
+	-- ACF.ActiveRadars for radars, need to check for direction and range for these
+	local ValidMissileRadars = {
+		["Active Radar"] = true
+	}
+
+	local function ReceiveSource(Receiver)
+		local RadarSource = {}
+
+		local ReceiverOrigin = Receiver:LocalToWorld(Receiver.Origin)
+
+		for k,v in pairs(ACF.ActiveRadars) do -- Radar entities
+			if k.EntType ~= "Targeting Radar" then continue end
+			local RadarOrigin = k:LocalToWorld(k.Origin)
+
+			if k.Range then -- Spherical
+				if RadarOrigin:DistToSqr(ReceiverOrigin) <= (k.Range ^ 2) then RadarSource[k] = true end
+			else -- Directional
+				if ACFM_ConeContainsPos(RadarOrigin, k:GetForward(), k.ConeDegs, ReceiverOrigin) then RadarSource[k] = true end
+			end
+		end
+
+		for k,v in pairs(ACF.ActiveMissiles) do -- Missile entities
+			if not k.UseGuidance then continue end -- Don't waste time on missiles that don't have functional guidance
+			if not ValidMissileRadars[k.Guidance] then continue end -- Further filter for anything without radar on the missile itself
+
+			if ACFM_ConeContainsPos(k.Position, k:GetForward(), k.ViewCone, ReceiverOrigin) then RadarSource[k] = true end
+		end
+
+		return RadarSource
+	end
+
+	local TraceData	  = { start = true, endpos = true, mask = MASK_SOLID_BRUSHONLY }
+	local function CheckLOS(_, _, Start, End)
+		TraceData.start = Start
+		TraceData.endpos = End
+
+		return not TraceLine(TraceData).Hit
+	end
+
+	Sensors.RegisterItem("RAD-Receiver", "WARN-Receiver", {
+		Name		= "Radar Warning Receiver",
+		Description	= "An unit designed to detect radar sources and give a vague direction.",
+		Model		= "models/jaanus/wiretool/wiretool_siren.mdl",
+
+		Mass		= 25,
+		Health		= 10,
+		Armor		= 10,
+		Offset 		= Vector(0,0,6),
+
+		ThinkDelay	= 0.5,
+		Divisor		= 30, -- Divisor (pre-floor) and then multiplier to give a choppy angle
+
+		Detect		= ReceiveSource,
+		CheckLOS	= CheckLOS,
+
+		Preview = {
+			FOV = 145,
+		},
+	})
+end

--- a/lua/acf/entities/sensors/receivers/receivers.lua
+++ b/lua/acf/entities/sensors/receivers/receivers.lua
@@ -87,7 +87,7 @@ do -- Radar Receiver
 
 		local ReceiverOrigin = Receiver:LocalToWorld(Receiver.Origin)
 
-		for k,v in pairs(ACF.ActiveRadars) do -- Radar entities
+		for k in pairs(ACF.ActiveRadars) do -- Radar entities
 			if k.EntType ~= "Targeting Radar" then continue end
 			local RadarOrigin = k:LocalToWorld(k.Origin)
 
@@ -98,7 +98,7 @@ do -- Radar Receiver
 			end
 		end
 
-		for k,v in pairs(ACF.ActiveMissiles) do -- Missile entities
+		for k in pairs(ACF.ActiveMissiles) do -- Missile entities
 			if not k.UseGuidance then continue end -- Don't waste time on missiles that don't have functional guidance
 			if not ValidMissileRadars[k.Guidance] then continue end -- Further filter for anything without radar on the missile itself
 

--- a/lua/acf/missiles/acfm_roundinject.lua
+++ b/lua/acf/missiles/acfm_roundinject.lua
@@ -239,6 +239,7 @@ else
 		Guidance:Configure(Entity)
 		Fuze:Configure(Entity)
 
+		Entity.Guidance		 = Data.Guidance
 		Entity.IsMissileAmmo = true
 		Entity.GuidanceData  = Guidance
 		Entity.FuzeData      = Fuze

--- a/lua/entities/acf_radar/init.lua
+++ b/lua/entities/acf_radar/init.lua
@@ -162,11 +162,14 @@ local function ScanForEntities(Entity)
 	local Velocity = TargetInfo.Velocity
 	local Distance = TargetInfo.Distance
 
+	local Damage = Entity.Damage
+	local Spread = ACF.MaxDamageInaccuracy * Damage
+
 	for Ent in pairs(Detected) do
 		local EntPos = Ent.Position or Ent:GetPos()
 
-		if CheckLOS(Origin, EntPos) then
-			local Spread = VectorRand(-Entity.Spread, Entity.Spread)
+		if CheckLOS(Origin, EntPos) and (math.Rand(0,1) >= (Damage / 10)) then
+			local Spread = VectorRand(-Spread, Spread)
 			local EntVel = Ent.Velocity or Ent:GetVelocity()
 			local Owner = GetEntityOwner(Entity.Owner, Ent)
 			local Index = GetEntityIndex(Ent)
@@ -400,7 +403,7 @@ do -- Spawn and Update functions
 		Radar.Active      = false
 		Radar.Scanning    = false
 		Radar.TargetCount = 0
-		Radar.Spread      = 0
+		Radar.Damage	  = 0
 		Radar.Weapons     = {}
 		Radar.Targets     = {}
 		Radar.DataStore   = Entities.GetArguments("acf_radar")
@@ -494,9 +497,13 @@ end
 function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 	local HitRes = Damage.doPropDamage(self, DmgResult, DmgInfo)
 
-	self.Spread = ACF.MaxDamageInaccuracy * (1 - math.Round(self.ACF.Health / self.ACF.MaxHealth, 2))
+	self.Damage = (1 - math.Round(self.ACF.Health / self.ACF.MaxHealth, 2))
 
 	return HitRes
+end
+
+function ENT:ACF_OnRepaired() -- OldArmor, OldHealth, Armor, Health
+	self.Damage = (1 - math.Round(self.ACF.Health / self.ACF.MaxHealth, 2))
 end
 
 function ENT:Enable()

--- a/lua/entities/acf_receiver/cl_init.lua
+++ b/lua/entities/acf_receiver/cl_init.lua
@@ -1,0 +1,5 @@
+include ("shared.lua")
+
+language.Add("Cleanup_acf_receiver", "ACF Receiver")
+language.Add("Cleaned_acf_receiver", "Cleaned up all ACF Receiverss")
+language.Add("SBoxLimit__acf_receiver", "You've hit the ACF Receiver limit!")

--- a/lua/entities/acf_receiver/init.lua
+++ b/lua/entities/acf_receiver/init.lua
@@ -1,0 +1,342 @@
+
+AddCSLuaFile("cl_init.lua")
+AddCSLuaFile("shared.lua")
+
+include("shared.lua")
+
+local ACF = ACF
+
+--===============================================================================================--
+-- Local Funcs and Vars
+--===============================================================================================--
+
+local Damage      = ACF.Damage
+local CheckLegal  = ACF_CheckLegal
+local Indexes	  = {}
+local Unused	  = {}
+local IndexCount  = 0
+local TimerExists = timer.Exists
+local TimerCreate = timer.Create
+local TimerRemove = timer.Remove
+local HookRun     = hook.Run
+
+local function ResetOutputs(Entity)
+	if not Entity.Detected then return end
+
+	Entity.Detected = false
+
+	WireLib.TriggerOutput(Entity, "Detected", 0)
+	WireLib.TriggerOutput(Entity, "Angle", Angle())
+	WireLib.TriggerOutput(Entity, "Direction", Vector())
+end
+
+local function CheckReceive(Entity)
+	local IsDetected = false
+	local Dir = Vector()
+	local Ang = Angle()
+
+	if not Entity.GetSources then return end
+	if not Entity.CheckLOS then return end
+
+	local Sources = Entity:GetSources()
+
+	local Origin = Entity:LocalToWorld(Entity.Origin)
+
+	for Ent in pairs(Sources) do
+		local EntPos = Ent.Position or Ent:GetPos()
+		local Damage = Entity.Damage
+		local Spread = math.max(Entity.Divisor,15) * 2 * Damage
+
+		if Entity.CheckLOS(Entity, Ent, Origin, EntPos) and (math.Rand(0,1) >= (Damage / 5)) then
+			IsDetected = true
+
+			local PreAng = (EntPos - Origin):GetNormalized():Angle()
+			Ang = Angle(math.Round((PreAng.p + math.random(-Spread,Spread)) / Entity.Divisor),math.Round((PreAng.y + math.random(-Spread,Spread)) / Entity.Divisor),0) * Entity.Divisor
+			Dir = Ang:Forward()
+
+			break -- Stop at the first valid source
+		end
+	end
+
+	if IsDetected ~= Entity.Detected then
+		Entity.Detected = IsDetected
+		WireLib.TriggerOutput(Entity, "Detected", IsDetected and 1 or 0)
+
+		if IsDetected then
+			Entity:EmitSound(Entity.SoundPath, 70, 100, ACF.Volume)
+		end
+
+		Entity:UpdateOverlay()
+	end
+
+	WireLib.TriggerOutput(Entity, "Direction", Dir)
+	WireLib.TriggerOutput(Entity, "Angle", Ang)
+end
+
+local function SetActive(Entity,Bool)
+	if Bool then
+		if not TimerExists(Entity.TimerID) then
+			TimerCreate(Entity.TimerID, Entity.ThinkDelay, 0, function()
+
+				if IsValid(Entity) then
+					return CheckReceive(Entity)
+				end
+
+				TimerRemove(Entity.TimerID)
+			end)
+		end
+	else
+		TimerRemove(Entity.TimerID)
+	end
+end
+
+--===============================================================================================--
+
+do -- Spawn and Update functions
+	local Classes  = ACF.Classes
+	local WireIO   = ACF.Utilities.WireIO
+	local Entities = Classes.Entities
+	local Sensors  = Classes.Sensors
+
+	local Outputs = {
+		"Detected (Returns 1 if it)",
+		"Direction (The direction to a source) [VECTOR]",
+		"Angle (The direction to a source) [ANGLE]",
+		"Entity (The receiver itself.) [ENTITY]"
+	}
+
+	local function VerifyData(Data)
+		if not Data.Receiver then
+			Data.Receiver = Data.Sensor or Data.Id
+		end
+
+		local Class = Classes.GetGroup(Sensors, Data.Receiver)
+
+		if not Class or Class.Entity ~= "acf_receiver" then
+			Data.Receiver = "LAS-Receiver"
+
+			Class = Classes.GetGroup(Sensors, "LAS-Receiver")
+		end
+
+		do -- External verifications
+			if Class.VerifyData then
+				Class.VerifyData(Data, Class)
+			end
+
+			HookRun("ACF_VerifyData", "acf_receiver", Data, Class)
+		end
+	end
+
+	local function UpdateReceiver(Entity, Data, Class, Receiver)
+		local Tick  = engine.TickInterval()
+		local Delay = Receiver.ThinkDelay
+
+		Entity.ACF = Entity.ACF or {}
+		Entity.ACF.Model = Receiver.Model -- Must be set before changing model
+
+		Entity:SetModel(Receiver.Model)
+
+		Entity:PhysicsInit(SOLID_VPHYSICS)
+		Entity:SetMoveType(MOVETYPE_VPHYSICS)
+
+		-- Storing all the relevant information on the entity for duping
+		for _, V in ipairs(Entity.DataStore) do
+			Entity[V] = Data[V]
+		end
+
+		Entity.Name         = Receiver.Name
+		Entity.ShortName    = Receiver.Name
+		Entity.EntType      = Class.Name
+		Entity.ClassType    = Class.ID
+		Entity.ClassData    = Class
+		Entity.SoundPath    = Class.Sound or ACF.DefaultRadarSound -- customizable sound?
+		Entity.DefaultSound = Entity.SoundPath
+		Entity.ThinkDelay   = math.Round(Delay / Tick) * Tick -- Uses a timer, so has to be tied to CurTime/tickrate
+		Entity.GetSources	= Receiver.Detect or Class.Detect
+		Entity.CheckLOS		= Receiver.CheckLOS
+		Entity.Origin       = Receiver.Offset
+		Entity.TimerID 		= "ACF Receiver Clock " .. Entity:EntIndex()
+		Entity.Divisor		= Receiver.Divisor
+		Entity.Cone			= Receiver.Cone
+
+		Entity.ForcedHealth	= Receiver.Health
+		Entity.ForcedArmor	= Receiver.Armor
+
+		WireIO.SetupOutputs(Entity, Outputs, Data, Class, Receiver)
+
+		Entity:SetNWString("WireName", "ACF " .. Entity.Name)
+
+		WireLib.TriggerOutput(Entity, "Think Delay", Entity.ThinkDelay)
+
+		ACF.Activate(Entity, true)
+
+		Entity.ACF.Model		= Receiver.Model
+		Entity.ACF.LegalMass	= Receiver.Mass
+
+		local Phys = Entity:GetPhysicsObject()
+		if IsValid(Phys) then Phys:SetMass(Receiver.Mass) end
+	end
+
+	function MakeACF_Receiver(Player, Pos, Angle, Data)
+		VerifyData(Data)
+
+		local Class = Classes.GetGroup(Sensors, Data.Receiver)
+		local ReceiverData = Class.Lookup[Data.Receiver]
+		local Limit = Class.LimitConVar.Name
+
+		if not Player:CheckLimit(Limit) then return false end
+
+		local Receiver = ents.Create("acf_receiver")
+
+		if not IsValid(Receiver) then return end
+
+		Receiver:SetPlayer(Player)
+		Receiver:SetAngles(Angle)
+		Receiver:SetPos(Pos)
+		Receiver:Spawn()
+
+		Player:AddCleanup("acf_receiver", Receiver)
+		Player:AddCount(Limit, Receiver)
+
+		Receiver.Owner       = Player -- MUST be stored on ent for PP
+		Receiver.DataStore   = Entities.GetArguments("acf_receiver")
+		Receiver.Damage		 = 0
+
+		UpdateReceiver(Receiver, Data, Class, ReceiverData)
+
+		if Class.OnSpawn then
+			Class.OnSpawn(Receiver, Data, Class, ReceiverData)
+		end
+
+		HookRun("ACF_OnEntitySpawn", "acf_receiver", Receiver, Data, Class, ReceiverData)
+
+		WireLib.TriggerOutput(Receiver, "Entity", Receiver)
+
+		Receiver:UpdateOverlay(true)
+
+		do -- Mass entity mod removal
+			local EntMods = Data and Data.EntityMods
+
+			if EntMods and EntMods.mass then
+				EntMods.mass = nil
+			end
+		end
+
+		CheckLegal(Receiver)
+
+		SetActive(Receiver,true)
+
+		return Receiver
+	end
+
+	Entities.Register("acf_receiver", MakeACF_Receiver, "Receiver")
+
+	------------------- Updating ---------------------
+
+	function ENT:Update(Data)
+		VerifyData(Data)
+
+		local Class    = Classes.GetGroup(Sensors, Data.Receiver)
+		local Receiver = Class.Lookup[Data.Receiver]
+		local OldClass = self.ClassData
+
+		if OldClass.OnLast then
+			OldClass.OnLast(self, OldClass)
+		end
+
+		HookRun("ACF_OnEntityLast", "acf_Receiver", self, OldClass)
+
+		ACF.SaveEntity(self)
+
+		UpdateReceiver(self, Data, Class, Receiver)
+
+		ACF.RestoreEntity(self)
+
+		if Class.OnUpdate then
+			Class.OnUpdate(self, Data, Class, Receiver)
+		end
+
+		HookRun("ACF_OnEntityUpdate", "acf_Receiver", self, Data, Class, Receiver)
+
+		self:UpdateOverlay(true)
+
+		net.Start("ACF_UpdateEntity")
+			net.WriteEntity(self)
+		net.Broadcast()
+
+		return true, "Receiver updated successfully!"
+	end
+end
+
+--===============================================================================================--
+-- Meta Funcs
+--===============================================================================================--
+
+function ENT:ACF_OnDamage(DmgResult, DmgInfo)
+	local HitRes = Damage.doPropDamage(self, DmgResult, DmgInfo)
+
+	self.Damage = 1 - math.Round(self.ACF.Health / self.ACF.MaxHealth, 2)
+
+	return HitRes
+end
+
+function ENT:ACF_OnRepaired() -- OldArmor, OldHealth, Armor, Health
+	self.Damage = 1 - math.Round(self.ACF.Health / self.ACF.MaxHealth, 2)
+end
+
+function ENT:ACF_Activate(Recalc)
+	local PhysObj = self.ACF.PhysObj
+	local Area    = PhysObj:GetSurfaceArea()
+	local Armor   = self.ForcedArmor
+	local Health  = self.ForcedHealth
+	local Percent = 1
+
+	if Recalc and self.ACF.Health and self.ACF.MaxHealth then
+		Percent = self.ACF.Health / self.ACF.MaxHealth
+	end
+
+	self.ACF.Area      = Area
+	self.ACF.Ductility = 0
+	self.ACF.Health    = Health * Percent
+	self.ACF.MaxHealth = Health
+	self.ACF.Armour    = Armor * (0.5 + Percent * 0.5)
+	self.ACF.MaxArmour = Armor * ACF.ArmorMod
+	self.ACF.Mass      = self.ForcedMass
+	self.ACF.Type      = "Prop"
+end
+
+function ENT:Enable()
+	if not CheckLegal(self) then return end
+
+	SetActive(self,true)
+
+	self:UpdateOverlay()
+end
+
+function ENT:Disable()
+	SetActive(self,false)
+end
+
+local Text = "%s\n\n%s"
+
+function ENT:UpdateOverlayText()
+	local Status, Range, Cone
+
+	Status = self.Detected and "Detected" or "Undetected"
+
+	return Text:format(Status, self.EntType)
+end
+
+function ENT:OnRemove()
+	local OldClass = self.ClassData
+
+	if OldClass.OnLast then
+		OldClass.OnLast(self, OldClass)
+	end
+
+	HookRun("ACF_OnEntityLast", "acf_Receiver", self, OldClass)
+
+	TimerRemove(self.TimerID)
+
+	WireLib.Remove(self)
+end

--- a/lua/entities/acf_receiver/init.lua
+++ b/lua/entities/acf_receiver/init.lua
@@ -12,9 +12,6 @@ local ACF = ACF
 
 local Damage      = ACF.Damage
 local CheckLegal  = ACF_CheckLegal
-local Indexes	  = {}
-local Unused	  = {}
-local IndexCount  = 0
 local TimerExists = timer.Exists
 local TimerCreate = timer.Create
 local TimerRemove = timer.Remove
@@ -44,10 +41,10 @@ local function CheckReceive(Entity)
 
 	for Ent in pairs(Sources) do
 		local EntPos = Ent.Position or Ent:GetPos()
-		local Damage = Entity.Damage
-		local Spread = math.max(Entity.Divisor,15) * 2 * Damage
+		local EntDamage = Entity.Damage
+		local Spread = math.max(Entity.Divisor,15) * 2 * EntDamage
 
-		if Entity.CheckLOS(Entity, Ent, Origin, EntPos) and (math.Rand(0,1) >= (Damage / 5)) then
+		if Entity.CheckLOS(Entity, Ent, Origin, EntPos) and (math.Rand(0,1) >= (EntDamage / 5)) then
 			IsDetected = true
 
 			local PreAng = (EntPos - Origin):GetNormalized():Angle()
@@ -74,6 +71,8 @@ local function CheckReceive(Entity)
 end
 
 local function SetActive(Entity,Bool)
+	ResetOutputs(Entity)
+
 	if Bool then
 		if not TimerExists(Entity.TimerID) then
 			TimerCreate(Entity.TimerID, Entity.ThinkDelay, 0, function()
@@ -177,7 +176,7 @@ do -- Spawn and Update functions
 		if IsValid(Phys) then Phys:SetMass(Receiver.Mass) end
 	end
 
-	function MakeACF_Receiver(Player, Pos, Angle, Data)
+	function MakeACF_Receiver(Player, Pos, Ang, Data)
 		VerifyData(Data)
 
 		local Class = Classes.GetGroup(Sensors, Data.Receiver)
@@ -191,7 +190,7 @@ do -- Spawn and Update functions
 		if not IsValid(Receiver) then return end
 
 		Receiver:SetPlayer(Player)
-		Receiver:SetAngles(Angle)
+		Receiver:SetAngles(Ang)
 		Receiver:SetPos(Pos)
 		Receiver:Spawn()
 
@@ -301,7 +300,6 @@ function ENT:ACF_Activate(Recalc)
 	self.ACF.MaxHealth = Health
 	self.ACF.Armour    = Armor * (0.5 + Percent * 0.5)
 	self.ACF.MaxArmour = Armor * ACF.ArmorMod
-	self.ACF.Mass      = self.ForcedMass
 	self.ACF.Type      = "Prop"
 end
 
@@ -320,9 +318,7 @@ end
 local Text = "%s\n\n%s"
 
 function ENT:UpdateOverlayText()
-	local Status, Range, Cone
-
-	Status = self.Detected and "Detected" or "Undetected"
+	local Status = self.Detected and "Detected" or "Undetected"
 
 	return Text:format(Status, self.EntType)
 end

--- a/lua/entities/acf_receiver/shared.lua
+++ b/lua/entities/acf_receiver/shared.lua
@@ -4,6 +4,6 @@ ENT.PrintName     = "ACF Receiver"
 ENT.Author        = "LiddulBOFH"
 ENT.WireDebugName = "ACF Receiver"
 ENT.PluralName    = "ACF Receivers"
-ENT.IsACFRadar       = true
+ENT.IsACFReceiver = true
 
 cleanup.Register("acf_receiver")

--- a/lua/entities/acf_receiver/shared.lua
+++ b/lua/entities/acf_receiver/shared.lua
@@ -1,0 +1,9 @@
+DEFINE_BASECLASS("acf_base_simple")
+
+ENT.PrintName     = "ACF Receiver"
+ENT.Author        = "LiddulBOFH"
+ENT.WireDebugName = "ACF Receiver"
+ENT.PluralName    = "ACF Receivers"
+ENT.IsACFRadar       = true
+
+cleanup.Register("acf_receiver")


### PR DESCRIPTION
- Fastforward dev to master

- Added radar/laser warning receivers These are capable of both telling that they are detected by their respective means, as well as provide a vague direction to the source

- Laser warning receiver requires line of sight to the source, and needs the laser source to be pointed nearly on the unit before it returns, but it gives a rather accurate direction to it (nearest 2.5 degrees). This is also set off by the Wiremod laserpointer.

- Radar warning receiver has the same requirements as a radar, and gives only a more vague direction (nearest 30 degrees) to the source. This is also set off by ACTIVE radar missiles, using their seek cone. This is NOT set off by missile-detecting radars, only targeting radars.

Both of these receivers update on a rather slow basis compared to other components, at a whopping 500ms for RWS, and 250ms for LWS.