### PR TITLE
Removed old Workshop download

### DIFF
--- a/lua/acf/core/acfm_globals.lua
+++ b/lua/acf/core/acfm_globals.lua
@@ -14,10 +14,6 @@ game.AddParticles("particles/flares_fx.pcf")
 
 PrecacheParticleSystem("ACFM_Flare")
 
-if SERVER then
-	resource.AddWorkshop("403587498")
-end
-
 do -- Update checker
 	hook.Add("ACF_OnLoadAddon", "ACF Missiles Checker", function()
 		ACF.AddRepository("TwistedTail", "ACF-3-Missiles", "lua/acf/core/acfm_globals.lua")

--- a/lua/entities/acf_computer/init.lua
+++ b/lua/entities/acf_computer/init.lua
@@ -67,7 +67,7 @@ end)
 -- Local Funcs and Vars
 --===============================================================================================--
 
-local CheckLegal  = ACF_CheckLegal
+local CheckLegal  = ACF.CheckLegal
 local UnlinkSound = "physics/metal/metal_box_impact_bullet%s.wav"
 local MaxDistance = ACF.LinkDistance * ACF.LinkDistance
 local HookRun     = hook.Run

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -29,7 +29,7 @@ end
 do -- Spawning and Updating --------------------
 	local UnlinkSound = "physics/metal/metal_box_impact_bullet%s.wav"
 	local MaxDistance = ACF.LinkDistance * ACF.LinkDistance
-	local CheckLegal  = ACF_CheckLegal
+	local CheckLegal  = ACF.CheckLegal
 	local WireIO      = Utilities.WireIO
 	local Entities    = Classes.Entities
 	local Racks       = Classes.Racks

--- a/lua/entities/acf_receiver/init.lua
+++ b/lua/entities/acf_receiver/init.lua
@@ -11,7 +11,7 @@ local ACF = ACF
 --===============================================================================================--
 
 local Damage      = ACF.Damage
-local CheckLegal  = ACF_CheckLegal
+local CheckLegal  = ACF.CheckLegal
 local TimerExists = timer.Exists
 local TimerCreate = timer.Create
 local TimerRemove = timer.Remove


### PR DESCRIPTION
No need to make clients download an outdated content pack when the main ACF-3 content pack already includes the missiles content (which needs an update for the recent LWR model though, btw). Also replaced all ACF_CheckLegal calls with ACF.CheckLegal so that it can be fully deprecated.