### PR TITLE
Super duper important fix

### DIFF
--- a/lua/acf/entities/sensors/receivers/receivers.lua
+++ b/lua/acf/entities/sensors/receivers/receivers.lua
@@ -30,6 +30,7 @@ do -- Laser Receiver
 		for _,ply in pairs(player.GetAll()) do
 			local Wep = ply:GetWeapon("laserpointer")
 			if not IsValid(Wep) then continue end
+			if Wep ~= ply:GetActiveWeapon() then continue end
 
 			if Wep.Pointing then
 				local Las = {Dir = ply:EyeAngles():Forward(),Position = ply:EyePos(),Player = ply}


### PR DESCRIPTION
Fixed the LWR's ability to detect wiremod laser pointer so it'll only get set off if its the active weapon, as opposed to always being set off as long as it was active