### PR TITLE
Dev Merge

### DIFF
--- a/lua/acf/core/utilities/entity_tracking_sv.lua
+++ b/lua/acf/core/utilities/entity_tracking_sv.lua
@@ -66,7 +66,7 @@ function ACF.GetEntitiesInCone(Position, Direction, Degrees, Contraption)
 	for Con in pairs(Contraptions) do
 		local Entity = Con.Ancestor
 		if not IsValid(Entity) then continue end
-		local EntityContraption = Entity:GetContraption()
+		local EntityContraption = Entity:CFW_GetContraption()
 		if Contraption and EntityContraption == Contraption then continue end
 
 		if ACF.LegalChecks and Entity:GetClass() == "acf_baseplate" and Entity.Disabled then continue end
@@ -86,7 +86,7 @@ function ACF.GetEntitiesInSphere(Position, Radius, Contraption)
 	for Con in pairs(Contraptions) do
 		local Entity = Con.Ancestor
 		if not IsValid(Entity) then continue end
-		if Contraption and Entity:GetContraption() == Contraption then continue end
+		if Contraption and Entity:CFW_GetContraption() == Contraption then continue end
 		-- Skip disabled baseplates here
 
 		if Position:DistToSqr(Entity:GetPos()) <= RadiusSqr then

--- a/lua/acf/core/utilities/entity_tracking_sv.lua
+++ b/lua/acf/core/utilities/entity_tracking_sv.lua
@@ -3,14 +3,25 @@ local Clock           = ACF.Utilities.Clock
 local Countermeasures = ACF.Classes.Countermeasures
 local Contraptions    = {}
 
-local ENTITY = FindMetaTable("Entity")
-local VECTOR = FindMetaTable("Vector")
+local ENTITY  = FindMetaTable("Entity")
+local PHYSOBJ = FindMetaTable("PhysObj")
+local VECTOR  = FindMetaTable("Vector")
+
+local IsEntityValid  = ACF.Optimizations.IsEntityValid
+local IsPhysObjValid = ACF.Optimizations.IsPhysObjValid
 
 local function UpdateValues(Contraption)
 	local Entity = Contraption.ACF_Baseplate
 	-- If legal checks are disabled, use any ancestor
-	if not ACF.LegalChecks and not IsValid(Entity) and Contraption and Contraption.families and next(Contraption.families) and next(Contraption.families).ancestor then Entity = next(Contraption.families).ancestor end
-	if not IsValid(Entity) then return end
+	if not ACF.LegalChecks and not IsEntityValid(Entity) and Contraption and Contraption.families then
+		local NextFamily = next(Contraption.families)
+		local Ancestor   = NextFamily.ancestor
+		if IsEntityValid(Ancestor) then
+			Entity = Ancestor
+		end
+	end
+
+	if not IsEntityValid(Entity) then return end
 
 	local SelfTable = ENTITY.GetTable(Entity)
 	local PhysObj   = ENTITY.GetPhysicsObject(Entity)
@@ -18,8 +29,8 @@ local function UpdateValues(Contraption)
 	local PrevPos   = SelfTable.ACF_Position
 	local Position
 
-	if IsValid(PhysObj) then
-		Position = ENTITY.LocalToWorld(Entity, PhysObj:GetMassCenter())
+	if IsPhysObjValid(PhysObj) then
+		Position = ENTITY.LocalToWorld(Entity, PHYSOBJ.GetMassCenter(PhysObj))
 	else
 		Position = ENTITY.GetPos(Entity)
 	end
@@ -27,7 +38,8 @@ local function UpdateValues(Contraption)
 	-- Entities being moved around by SetPos will have a velocity of 0
 	-- By using the difference between positions we can get a proper value
 	if VECTOR.LengthSqr(Velocity) == 0 and PrevPos then
-		Velocity = (Position - PrevPos) / Clock.DeltaTime
+		Velocity = Position - PrevPos
+		VECTOR.Div(Velocity, Clock.DeltaTime)
 	end
 
 	SelfTable.ACF_Position = Position

--- a/lua/acf/core/utilities/entity_tracking_sv.lua
+++ b/lua/acf/core/utilities/entity_tracking_sv.lua
@@ -58,6 +58,10 @@ hook.Add("cfw.contraption.removed", "ACF Entity Tracking", function(Contraption)
 	Contraptions[Contraption] = nil
 end)
 
+hook.Add("cfw.contraption.merged", "ACF Entity Tracking", function(Contraption)
+	Contraptions[Contraption] = nil
+end)
+
 hook.Add("ACF_OnTick", "ACF Entity Tracking", function()
 	for Contraption in pairs(Contraptions) do UpdateValues(Contraption) end
 end)

--- a/lua/acf/core/utilities/entity_tracking_sv.lua
+++ b/lua/acf/core/utilities/entity_tracking_sv.lua
@@ -15,9 +15,11 @@ local function UpdateValues(Contraption)
 	-- If legal checks are disabled, use any ancestor
 	if not ACF.LegalChecks and not IsEntityValid(Entity) and Contraption and Contraption.families then
 		local NextFamily = next(Contraption.families)
-		local Ancestor   = NextFamily.ancestor
-		if IsEntityValid(Ancestor) then
-			Entity = Ancestor
+		if NextFamily then
+			local Ancestor   = NextFamily.ancestor
+			if IsEntityValid(Ancestor) then
+				Entity = Ancestor
+			end
 		end
 	end
 

--- a/lua/acf/core/utilities/entity_tracking_sv.lua
+++ b/lua/acf/core/utilities/entity_tracking_sv.lua
@@ -3,31 +3,35 @@ local Clock           = ACF.Utilities.Clock
 local Countermeasures = ACF.Classes.Countermeasures
 local Contraptions    = {}
 
+local ENTITY = FindMetaTable("Entity")
+local VECTOR = FindMetaTable("Vector")
+
 local function UpdateValues(Contraption)
 	local Entity = Contraption.ACF_Baseplate
 	-- If legal checks are disabled, use any ancestor
 	if not ACF.LegalChecks and not IsValid(Entity) and Contraption and Contraption.families and next(Contraption.families) and next(Contraption.families).ancestor then Entity = next(Contraption.families).ancestor end
 	if not IsValid(Entity) then return end
 
-	local PhysObj  = Entity:GetPhysicsObject()
-	local Velocity = Entity:GetVelocity()
-	local PrevPos  = Entity.ACF_Position
+	local SelfTable = ENTITY.GetTable(Entity)
+	local PhysObj   = ENTITY.GetPhysicsObject(Entity)
+	local Velocity  = ENTITY.GetVelocity(Entity)
+	local PrevPos   = SelfTable.ACF_Position
 	local Position
 
 	if IsValid(PhysObj) then
-		Position = Entity:LocalToWorld(PhysObj:GetMassCenter())
+		Position = ENTITY.LocalToWorld(Entity, PhysObj:GetMassCenter())
 	else
-		Position = Entity:GetPos()
+		Position = ENTITY.GetPos(Entity)
 	end
 
 	-- Entities being moved around by SetPos will have a velocity of 0
 	-- By using the difference between positions we can get a proper value
-	if Velocity:LengthSqr() == 0 and PrevPos then
+	if VECTOR.LengthSqr(Velocity) == 0 and PrevPos then
 		Velocity = (Position - PrevPos) / Clock.DeltaTime
 	end
 
-	Entity.ACF_Position = Position
-	Entity.ACF_Velocity = Velocity
+	SelfTable.ACF_Position = Position
+	SelfTable.ACF_Velocity = Velocity
 	Contraption.Ancestor = Entity
 end
 

--- a/lua/acf/core/utilities/entity_tracking_sv.lua
+++ b/lua/acf/core/utilities/entity_tracking_sv.lua
@@ -11,7 +11,7 @@ local function UpdateValues(Contraption)
 
 	local PhysObj  = Entity:GetPhysicsObject()
 	local Velocity = Entity:GetVelocity()
-	local PrevPos  = Entity.Position
+	local PrevPos  = Entity.ACF_Position
 	local Position
 
 	if IsValid(PhysObj) then
@@ -26,8 +26,8 @@ local function UpdateValues(Contraption)
 		Velocity = (Position - PrevPos) / Clock.DeltaTime
 	end
 
-	Entity.Position = Position
-	Entity.Velocity = Velocity
+	Entity.ACF_Position = Position
+	Entity.ACF_Velocity = Velocity
 	Contraption.Ancestor = Entity
 end
 

--- a/lua/acf/entities/fuzes/altitude.lua
+++ b/lua/acf/entities/fuzes/altitude.lua
@@ -11,9 +11,10 @@ else
 	end
 
 	function Fuze:GetDetonate(Missile, Guidance)
-		if not self:IsArmed() then return false end
+		if not self:IsArmed() or not Guidance then return false end
 
-		local Target = Guidance.TargetPos or Guidance:GetGuidance(Missile).TargetPos
+		local GuidanceResult = Guidance:GetGuidance(Missile)
+		local Target = Guidance.TargetPos or (GuidanceResult and GuidanceResult.TargetPos)
 		if not Target then return false end
 
 		local TargetElevation = Target.z

--- a/lua/acf/entities/fuzes/radio.lua
+++ b/lua/acf/entities/fuzes/radio.lua
@@ -15,6 +15,6 @@ else
 
 		if not Target then return false end
 
-		return Missile.Position:Distance(Target) <= self.Distance
+		return Missile.ACF_Position:Distance(Target) <= self.Distance
 	end
 end

--- a/lua/acf/entities/guidance/active_radar.lua
+++ b/lua/acf/entities/guidance/active_radar.lua
@@ -10,13 +10,13 @@ else
 	end
 
 	function Guidance:SeekTarget(Missile)
-		local Position   = Missile.Position
+		local Position   = Missile.ACF_Position
 		local Targets    = ACF.GetEntitiesInCone(Position, Missile:GetForward(), self.SeekCone)
 		local HighestDot = 0
 		local Target, TargetPos
 
 		for Entity in pairs(Targets) do
-			local EntPos   = Entity.Position
+			local EntPos   = Entity.ACF_Position
 			local Distance = Position:DistToSqr(EntPos)
 
 			if Distance < self.MinDistance then continue end

--- a/lua/acf/entities/guidance/antimissile.lua
+++ b/lua/acf/entities/guidance/antimissile.lua
@@ -24,7 +24,7 @@ else
 	end
 
 	function Guidance:SeekTarget(Missile)
-		local Position   = Missile.Position
+		local Position   = Missile.ACF_Position
 		local Targets    = Countermeasures.GetMissilesInCone(Position, Missile:GetForward(), self.SeekCone)
 		local HighestDot = 0
 		local Target, TargetPos
@@ -33,7 +33,7 @@ else
 			if Missile == Entity then continue end
 			if Entity.IsAntiMissile then continue end
 
-			local EntPos   = Entity.Position
+			local EntPos   = Entity.ACF_Position
 			local Distance = Position:DistToSqr(EntPos)
 
 			if Distance < self.MinDistance then continue end
@@ -60,7 +60,7 @@ else
 		end
 
 		local Targets    = Radar.Targets
-		local Position   = Missile.Position
+		local Position   = Missile.ACF_Position
 		local HighestDot = 0
 		local Target, TargetPos
 
@@ -100,7 +100,7 @@ else
 
 		if not IsValid(Target) then return end
 
-		local Position = Target.Position
+		local Position = Target.ACF_Position
 
 		if self.OnRadar then
 			if not Radar then return end
@@ -119,7 +119,7 @@ else
 		local Radar     = self:GetRadar()
 		local TargetPos = self:GetTargetPosition(Radar)
 
-		if TargetPos and self:CheckConeLOS(Missile, Missile.Position, TargetPos, self.ViewConeCos) then
+		if TargetPos and self:CheckConeLOS(Missile, Missile.ACF_Position, TargetPos, self.ViewConeCos) then
 			return { TargetPos = TargetPos, ViewCone = self.ViewCone }
 		end
 

--- a/lua/acf/entities/guidance/antiradiation.lua
+++ b/lua/acf/entities/guidance/antiradiation.lua
@@ -28,7 +28,7 @@ else
 	function Guidance:UpdateTarget(Missile)
 		if not next(Radars) then return end
 
-		local Position = Missile.Position
+		local Position = Missile.ACF_Position
 		local HighestDot = 0
 		local Target, TargetPos
 
@@ -69,7 +69,7 @@ else
 	function Guidance:GetGuidance(Missile)
 		local TargetPos = self:GetTargetPosition()
 
-		if TargetPos and self:CheckConeLOS(Missile, Missile.Position, TargetPos, self.ViewConeCos) then
+		if TargetPos and self:CheckConeLOS(Missile, Missile.ACF_Position, TargetPos, self.ViewConeCos) then
 			return { TargetPos = TargetPos, ViewCone = self.ViewCone }
 		end
 

--- a/lua/acf/entities/guidance/infrared.lua
+++ b/lua/acf/entities/guidance/infrared.lua
@@ -10,13 +10,13 @@ else
 	end
 
 	function Guidance:UpdateTarget(Missile)
-		local Position   = Missile.Position
+		local Position   = Missile.ACF_Position
 		local Targets    = ACF.GetEntitiesInCone(Position, Missile:GetForward(), self.SeekCone)
 		local HighestDot = 0
 		local Target, TargetPos
 
 		for Entity in pairs(Targets) do
-			local EntPos   = Entity.Position
+			local EntPos   = Entity.ACF_Position
 			local Distance = Position:DistToSqr(EntPos)
 
 			if Distance < self.MinDistance then continue end
@@ -41,7 +41,7 @@ else
 
 		if not IsValid(Target) then return end
 
-		return Target.Position
+		return Target.ACF_Position
 	end
 
 	function Guidance:GetGuidance(Missile)
@@ -53,7 +53,7 @@ else
 
 		local TargetPos = self:GetTargetPosition()
 
-		if TargetPos and self:CheckConeLOS(Missile, Missile.Position, TargetPos, self.ViewConeCos) then
+		if TargetPos and self:CheckConeLOS(Missile, Missile.ACF_Position, TargetPos, self.ViewConeCos) then
 			return { TargetPos = TargetPos, ViewCone = self.ViewCone }
 		end
 

--- a/lua/acf/entities/guidance/laser.lua
+++ b/lua/acf/entities/guidance/laser.lua
@@ -25,7 +25,7 @@ else
 	end
 
 	function Guidance.GetDirectionDot(Missile, TargetPos)
-		local Position = Missile.Position
+		local Position = Missile.ACF_Position
 		local Forward = Missile:GetForward()
 		local Direction = (TargetPos - Position):GetNormalized()
 
@@ -48,7 +48,7 @@ else
 		if not Computer.IsLaserSource then return end
 		if not Computer.Lasing then return end
 
-		local Position = Missile.Position
+		local Position = Missile.ACF_Position
 		local HitPos = Computer.HitPos
 
 		if not self:CheckConeLOS(Missile, Position, HitPos, self.ViewConeCos) then return end
@@ -63,7 +63,7 @@ else
 
 		if HitPos then return { TargetPos = HitPos } end
 
-		local Position = Missile.Position
+		local Position = Missile.ACF_Position
 		local HighestDot = 0
 		local CurrentDot
 

--- a/lua/acf/entities/guidance/semi_active_radar.lua
+++ b/lua/acf/entities/guidance/semi_active_radar.lua
@@ -22,7 +22,7 @@ else
 		end
 
 		local Targets    = Radar.Targets
-		local Position   = Missile.Position
+		local Position   = Missile.ACF_Position
 		local HighestDot = 0
 		local Target, TargetPos
 

--- a/lua/acf/entities/missiles/asm.lua
+++ b/lua/acf/entities/missiles/asm.lua
@@ -265,7 +265,8 @@ Missiles.RegisterItem("9M133 ASM", "ATGM", {
 	},
 })
 
-Missiles.AddItemAlias("ATGM", "9M133 ASM", "9M113 ASM")
+-- TODO: This is the ONLY use of the alias system in Missiles. I would guess its for ACF2 -> ACF3 compatibility? hopefully...
+-- Missiles.AddItemAlias("ATGM", "9M133 ASM", "9M113 ASM")
 
 Missiles.RegisterItem("AT-2 ASM", "ATGM", {
 	Name		= "9M17 Fleyta",

--- a/lua/acf/entities/sensors/radars/targeting.lua
+++ b/lua/acf/entities/sensors/radars/targeting.lua
@@ -15,7 +15,7 @@ Sensors.Register("TGT-Radar", {
 
 do -- Directional radars
 	local function DetectEntities(Radar)
-		return ACF.GetEntitiesInCone(Radar:LocalToWorld(Radar.Origin), Radar:GetForward(), Radar.ConeDegs, Radar:GetContraption())
+		return ACF.GetEntitiesInCone(Radar:LocalToWorld(Radar.Origin), Radar:GetForward(), Radar.ConeDegs, Radar:CFW_GetContraption())
 	end
 
 	Sensors.RegisterItem("SmallDIR-TGT", "TGT-Radar", {
@@ -70,7 +70,7 @@ end
 
 do -- Spherical radars
 	local function DetectEntities(Radar)
-		return ACF.GetEntitiesInSphere(Radar:LocalToWorld(Radar.Origin), Radar.Range, Radar:GetContraption())
+		return ACF.GetEntitiesInSphere(Radar:LocalToWorld(Radar.Origin), Radar.Range, Radar:CFW_GetContraption())
 	end
 
 	Sensors.RegisterItem("SmallOMNI-TGT", "TGT-Radar", {

--- a/lua/acf/entities/sensors/receivers/receivers.lua
+++ b/lua/acf/entities/sensors/receivers/receivers.lua
@@ -105,7 +105,7 @@ do -- Radar Receiver
 			if not k.UseGuidance then continue end -- Don't waste time on missiles that don't have functional guidance
 			if not ValidMissileRadars[k.Guidance] then continue end -- Further filter for anything without radar on the missile itself
 
-			if Countermeasures.ConeContainsPos(k.Position, k:GetForward(), k.ViewCone, ReceiverOrigin) then RadarSource[k] = true end
+			if Countermeasures.ConeContainsPos(k.ACF_Position, k:GetForward(), k.ViewCone, ReceiverOrigin) then RadarSource[k] = true end
 		end
 
 		return RadarSource

--- a/lua/acf/menu/items_cl/missiles.lua
+++ b/lua/acf/menu/items_cl/missiles.lua
@@ -60,8 +60,10 @@ local function CreateMenu(Menu)
 	Menu:AddTitle("Missile Settings")
 
 	local MissileTypes = Menu:AddComboBox()
+	MissileTypes:SetName("MissileTypes")
 	local MissileList = Menu:AddComboBox()
-
+	MissileList:SetName("MissileList")
+	
 	local MissileBase = Menu:AddCollapsible("Missile Information")
 	local MissileClass = MissileBase:AddLabel()
 	local MissileDesc = MissileBase:AddLabel()

--- a/lua/acf/menu/items_cl/missiles.lua
+++ b/lua/acf/menu/items_cl/missiles.lua
@@ -63,7 +63,7 @@ local function CreateMenu(Menu)
 	MissileTypes:SetName("MissileTypes")
 	local MissileList = Menu:AddComboBox()
 	MissileList:SetName("MissileList")
-	
+
 	local MissileBase = Menu:AddCollapsible("Missile Information")
 	local MissileClass = MissileBase:AddLabel()
 	local MissileDesc = MissileBase:AddLabel()

--- a/lua/acf/missiles/acfm_roundinject.lua
+++ b/lua/acf/missiles/acfm_roundinject.lua
@@ -57,7 +57,7 @@ if CLIENT then
 		local Missile      = Base.MissileData
 		local GuidanceList = Base:AddComboBox()
 		GuidanceList:SetName("GuidanceList")
-		local GuidanceBase = Base:AddPanel("ACF_Panel")	
+		local GuidanceBase = Base:AddPanel("ACF_Panel")
 		local FuzeList     = Base:AddComboBox()
 		FuzeList:SetName("FuzeList")
 		local FuzeBase     = Base:AddPanel("ACF_Panel")

--- a/lua/acf/missiles/acfm_roundinject.lua
+++ b/lua/acf/missiles/acfm_roundinject.lua
@@ -56,8 +56,10 @@ if CLIENT then
 
 		local Missile      = Base.MissileData
 		local GuidanceList = Base:AddComboBox()
-		local GuidanceBase = Base:AddPanel("ACF_Panel")
+		GuidanceList:SetName("GuidanceList")
+		local GuidanceBase = Base:AddPanel("ACF_Panel")	
 		local FuzeList     = Base:AddComboBox()
+		FuzeList:SetName("FuzeList")
 		local FuzeBase     = Base:AddPanel("ACF_Panel")
 
 		function GuidanceList:OnSelect(Index, Name, Data)

--- a/lua/entities/acf_glatgm/init.lua
+++ b/lua/entities/acf_glatgm/init.lua
@@ -13,8 +13,8 @@ local TraceData  = { start = true, endpos = true, filter = true }
 local ZERO       = Vector()
 
 local function CheckViewCone(Missile, HitPos)
-	local Position = Missile.Position
-	local Forward  = Missile.Velocity:GetNormalized()
+	local Position = Missile.ACF_Position
+	local Forward  = Missile.ACF_Velocity:GetNormalized()
 	local Direction = (HitPos - Position):GetNormalized()
 
 	return Direction:Dot(Forward) >= Missile.ViewCone
@@ -99,8 +99,8 @@ function ACF.MakeGLATGM(Player, Gun, BulletData)
 	Entity.SpiralRadius = Entity.IsSubcaliber and 120 / Caliber or nil
 	Entity.SpiralSpeed  = Entity.IsSubcaliber and 360 / Entity.AccelLength or nil
 	Entity.SpiralAngle  = Entity.IsSubcaliber and 0 or nil
-	Entity.Position     = BulletData.Pos
-	Entity.Velocity     = BulletData.Flight:GetNormalized() * Entity.LaunchVel
+	Entity.ACF_Position = BulletData.Pos
+	Entity.ACF_Velocity = BulletData.Flight:GetNormalized() * Entity.LaunchVel
 	Entity.Inaccuracy   = 0
 
 	Entity.Filter[#Entity.Filter + 1] = Entity
@@ -224,7 +224,7 @@ function ENT:Think()
 	local CanGuide  = self.GuideDelay <= Time
 	local Computer  = self:GetComputer()
 	local CanSee    = IsValid(Computer) and CheckViewCone(self, Computer.HitPos)
-	local Position  = self.Position
+	local Position  = self.ACF_Position
 	local NextDir, NextAng
 
 	self.Speed = self.LaunchVel + self.DiffVel * math.Clamp(1 - (self.AccelTime - Time) / self.AccelLength, 0, 1)
@@ -234,7 +234,7 @@ function ENT:Think()
 		local Distance    = Origin:Distance(Position) + self.Speed * 0.15
 		local Target      = Origin + Computer.TraceDir * Distance
 		local Expected    = (Target - Position):GetNormalized():Angle()
-		local Current     = self.Velocity:GetNormalized():Angle()
+		local Current     = self.ACF_Velocity:GetNormalized():Angle()
 		local _, LocalAng = WorldToLocal(Target, Expected, Position, Current)
 		local Clamped     = ClampAngle(LocalAng, self.Agility * DeltaTime)
 		local _, WorldAng = LocalToWorld(Vector(), Clamped, Position, Current)
@@ -247,7 +247,7 @@ function ENT:Think()
 		local Spread = self.Inaccuracy * DeltaTime * 0.005
 		local Added  = VectorRand() * Spread
 
-		NextDir = (self.Velocity:GetNormalized() + Added):GetNormalized()
+		NextDir = (self.ACF_Velocity:GetNormalized() + Added):GetNormalized()
 		NextAng = NextDir:Angle()
 
 		self.Inaccuracy = self.Inaccuracy + DeltaTime * 50
@@ -266,22 +266,22 @@ function ENT:Think()
 	end
 
 
-	self.Position = self.Position + NextDir * self.Speed * DeltaTime
-	self.Velocity = (self.Position - Position) / DeltaTime
+	self.ACF_Position = self.ACF_Position + NextDir * self.Speed * DeltaTime
+	self.ACF_Velocity = (self.ACF_Position - Position) / DeltaTime
 
 	TraceData.start  = Position
-	TraceData.endpos = self.Position
+	TraceData.endpos = self.ACF_Position
 	TraceData.filter = self.Filter
 
 	local Result = ACF.trace(TraceData)
 
 	if Result.Hit then
-		self.Position = Result.HitPos
+		self.ACF_Position = Result.HitPos
 
 		return self:Detonate()
 	end
 
-	self:SetPos(self.Position)
+	self:SetPos(self.ACF_Position)
 	self:SetAngles(NextAng)
 	self:NextThink(Time)
 
@@ -294,10 +294,10 @@ function ENT:Detonate()
 	if self.Detonated then return end
 
 	local BulletData = self.BulletData
-	local Position   = self.Position
+	local Position   = self.ACF_Position
 
 	BulletData.Filter = self.Filter
-	BulletData.Flight = self.Velocity:GetNormalized() * self.Speed
+	BulletData.Flight = self.ACF_Velocity:GetNormalized() * self.Speed
 	BulletData.Pos    = Position
 	BulletData.DetonatorAngle = 91
 

--- a/lua/entities/acf_groundloader/init.lua
+++ b/lua/entities/acf_groundloader/init.lua
@@ -134,7 +134,7 @@ do
 		-- Only allow baseplate-parented & aircraft baseplates.
 		local Rack       = self.Rack
 
-		local Contraption = Rack:GetContraption()
+		local Contraption = Rack:CFW_GetContraption()
 		if not Contraption then self.Complete = true return end
 
 		local Base = Contraption.ACF_Baseplate

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -107,7 +107,7 @@ end
 local function Dud(Missile)
 	local PhysObj   = Missile:GetPhysicsObject()
 	local HitNormal = Missile.HitNormal
-	local Velocity  = Missile.Velocity
+	local Velocity  = Missile.ACF_Velocity
 	local CurDir    = Missile.CurDir
 
 	if HitNormal then
@@ -174,7 +174,7 @@ local function CalcFlight(Missile)
 
 	if DeltaTime <= 0 then return end
 
-	local Pos            = Missile.Position
+	local Pos            = Missile.ACF_Position
 	local Dir            = Missile.CurDir
 	local LastVel        = Missile.LastVel
 	local LastSpeed      = LastVel:Length()
@@ -190,7 +190,7 @@ local function CalcFlight(Missile)
 	local Guidance    = Missile.UseGuidance and Missile.GuidanceData:GetGuidance(Missile)
 	local TargetPos   = Guidance and Guidance.TargetPos
 
-	-- debugoverlay.Line(Missile.Position, TargetPos, 10, Color(0, 0, 255), true)
+	-- debugoverlay.Line(Missile.ACF_Position, TargetPos, 10, Color(0, 0, 255), true)
 	if TargetPos then
 		-- Getting the relative position, velocity and acceleration
 		local RelPos = TargetPos - Pos
@@ -233,7 +233,7 @@ local function CalcFlight(Missile)
 	DirAng:RotateAroundAxis(Missile.RotAxis:GetNormalized(), Missile.RotAxis:Length() * DeltaTime)
 	Dir = DirAng:Forward()
 	Missile.RotAxis = Missile.RotAxis * (1 - 0.7 * DeltaTime)
-	-- debugoverlay.Line(Missile.Position, Missile.Position + Missile.RotAxis * 10, 10, Color(255, 0, 0), true)
+	-- debugoverlay.Line(Missile.ACF_Position, Missile.ACF_Position + Missile.RotAxis * 10, 10, Color(255, 0, 0), true)
 
 	local FuelMod = math.Clamp(Missile.MotorLength / DeltaTime, 0, 1)
 	if Missile.MotorEnabled then
@@ -253,14 +253,14 @@ local function CalcFlight(Missile)
 	local DotSimple = Up.x * VelNorm.x + Up.y * VelNorm.y + Up.z * VelNorm.z
 	local Lift      = -Up * DotSimple * LiftMultiplier
 
-	-- debugoverlay.Line(Missile.Position, Missile.Position + VelNorm * 10, 10, Color(0, 0, 255), true)
-	-- debugoverlay.Line(Missile.Position, Missile.Position + Up * 10, 10, Color(255, 0, 0), true)
-	-- debugoverlay.Line(Missile.Position, Missile.Position + Dir * 10, 10, Color(255, 0, 0), true)
+	-- debugoverlay.Line(Missile.ACF_Position, Missile.ACF_Position + VelNorm * 10, 10, Color(0, 0, 255), true)
+	-- debugoverlay.Line(Missile.ACF_Position, Missile.ACF_Position + Up * 10, 10, Color(255, 0, 0), true)
+	-- debugoverlay.Line(Missile.ACF_Position, Missile.ACF_Position + Dir * 10, 10, Color(255, 0, 0), true)
 	local Drag      = LastVel * (Missile.DragCoef * LastSpeed) / ACF.DragDiv * ACF.Scale / Missile.Mass
 	local Vel       = LastVel + (GravityVector + Thrust + Lift - Drag) * DeltaTime
 	local EndPos    = Pos + Vel * DeltaTime
 
-	Missile.Velocity = Vel
+	Missile.ACF_Velocity = Vel
 
 	--Hit detection
 	TraceData.start = Pos
@@ -301,7 +301,7 @@ local function CalcFlight(Missile)
 
 	Missile.LastVel = Vel
 	Missile.LastPos = Pos
-	Missile.Position = EndPos
+	Missile.ACF_Position = EndPos
 	Missile.CurDir = Dir
 
 	--Missile trajectory debugging
@@ -510,7 +510,7 @@ function ENT:Launch(Delay, IsMisfire)
 	local Point      = self.MountPoint
 	local Rack       = self.Launcher
 	local Flight     = BulletData.Flight or self:LocalToWorldAngles(Point.Angle):Forward()
-	local Velocity   = Rack.Velocity + self.SpeedBoost * Flight
+	local Velocity   = Rack.ACF_Velocity + self.SpeedBoost * Flight
 	local DeltaTime  = engine.TickInterval()
 
 	if Rack.SoundPath and Rack.SoundPath ~= "" then
@@ -520,16 +520,16 @@ function ENT:Launch(Delay, IsMisfire)
 	BulletData.Flight = Velocity
 	BulletData.Pos    = Rack:LocalToWorld(Point.Position)
 
-	self.Launched    = true
-	self.ThinkDelay  = DeltaTime
-	self.GhostPeriod = Clock.CurTime + ACF.GhostPeriod
-	self.NoDamage    = nil
-	self.LastThink   = Clock.CurTime - DeltaTime
-	self.Position    = BulletData.Pos
-	self.LastPos     = self.Position
-	self.Velocity    = Velocity
-	self.LastVel     = Velocity
-	self.CurDir      = Flight
+	self.Launched     = true
+	self.ThinkDelay   = DeltaTime
+	self.GhostPeriod  = Clock.CurTime + ACF.GhostPeriod
+	self.NoDamage     = nil
+	self.LastThink    = Clock.CurTime - DeltaTime
+	self.ACF_Position = BulletData.Pos
+	self.LastPos      = self.ACF_Position
+	self.ACF_Velocity = Velocity
+	self.LastVel      = Velocity
+	self.CurDir       = Flight
 
 	if self.RackModel then
 		self:UpdateModel(self.RealModel)
@@ -576,7 +576,7 @@ function ENT:Launch(Delay, IsMisfire)
 end
 
 function ENT:DoFlight(ToPos, ToDir)
-	local NewPos = ToPos or self.Position
+	local NewPos = ToPos or self.ACF_Position
 	local NewDir = ToDir or self.CurDir
 
 	-- Destroy the missile if it is out of bounds. Allow OOB upward, though.
@@ -626,7 +626,7 @@ function ENT:Detonate(Destroyed)
 	end
 
 	BulletData.Pos = BulletData.Pos or   self:GetPos()
-	BulletData.Flight = self.Velocity or Vector(0, 0, 0)
+	BulletData.Flight = self.ACF_Velocity or Vector(0, 0, 0)
 
 	if IsValid(PhysObj) then
 		PhysObj:EnableMotion(false)

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -91,7 +91,7 @@ do
 
 	function ENT:UpdateLoadMod()
 		self.CrewsByType = self.CrewsByType or {}
-		if IsValid(self.Autoloader) and self.Autoloader.ACF.Health > 0 then
+		if IsValid(self.Autoloader) and self.Autoloader.ACF.Health > 0 and table.Count(self.MountPoints) == 1 then
 			local Sum1 = self.Autoloader:GetReloadEffAuto(self, self.CurrentCrate)
 			self.LoadCrewMod = self.LoadCrewModOverride or math.Clamp(Sum1, ACF.AutoloaderFallbackCoef, ACF.AutoloaderMaxBonus)
 		else

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -1174,17 +1174,17 @@ do -- Misc -------------------------------------
 
 	function ENT:Think()
 		local Time     = Clock.CurTime
-		local Previous = self.Position
+		local Previous = self.ACF_Position
 		local Current  = GetPosition(self)
 
-		self.Position = Current
+		self.ACF_Position = Current
 
 		if Previous then
 			local DeltaTime = Time - self.LastThink
 
-			self.Velocity = (Current - Previous) / DeltaTime
+			self.ACF_Velocity = (Current - Previous) / DeltaTime
 		else
-			self.Velocity = Vector()
+			self.ACF_Velocity = Vector()
 		end
 
 		self:NextThink(Time)

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -740,7 +740,7 @@ do -- Firing -----------------------------------
 		Rack:UpdateLoad(Point)
 
 		-- Mark contraption as in combat when firing
-		local Contraption = Rack:GetContraption()
+		local Contraption = Rack:CFW_GetContraption()
 		if Contraption then
 			Contraption.InCombat = engine.TickCount()
 		end

--- a/lua/entities/acf_radar/init.lua
+++ b/lua/entities/acf_radar/init.lua
@@ -168,11 +168,11 @@ local function ScanForEntities(Entity)
 	local Spread = ACF.MaxDamageInaccuracy * EntDamage
 
 	for Ent in pairs(Detected) do
-		local EntPos = Ent.Position or Ent:GetPos()
+		local EntPos = Ent.ACF_Position or Ent:GetPos()
 
 		if CheckLOS(Origin, EntPos) and (math.Rand(0, 1) >= (EntDamage / 10)) then
 			local EntSpread = VectorRand(-Spread, Spread)
-			local EntVel = Ent.Velocity or Ent:GetVelocity()
+			local EntVel = Ent.ACF_Velocity or Ent:GetVelocity()
 			local Owner = GetEntityOwner(Entity.Owner, Ent)
 			local Index = GetEntityIndex(Ent)
 

--- a/lua/entities/acf_radar/init.lua
+++ b/lua/entities/acf_radar/init.lua
@@ -185,8 +185,8 @@ local function ScanForEntities(Entity)
 			local EntSize = 0
 			if Ent.IsACFMissile then
 				EntSize = (Ent.Caliber or 0) / ACF.InchToMm
-			elseif Ent:GetContraption() then
-				local Mins, Maxs, _ = Ent:GetContraption():GetAABB()
+			elseif Ent:CFW_GetContraption() then
+				local Mins, Maxs, _ = Ent:CFW_GetContraption():GetAABB()
 				EntSize = (Maxs - Mins):Length()
 			end
 			EntSize = math.Round(EntSize) -- Round to nearest inch

--- a/lua/entities/acf_radar/init.lua
+++ b/lua/entities/acf_radar/init.lua
@@ -451,6 +451,10 @@ do -- Spawn and Update functions
 	Entities.Register("acf_missileradar", ACF.MakeRadar, "Radar") -- Backwards compatibility
 	Entities.Register("acf_radar", ACF.MakeRadar, "Radar")
 
+	-- Compatibility with ACE radar entities
+	Entities.Register("ace_trackingradar", ACF.MakeRadar, "Radar")
+	Entities.Register("ace_searchradar", ACF.MakeRadar, "Radar")
+
 	ACF.RegisterLinkSource("acf_radar", "Weapons")
 
 	------------------- Updating ---------------------

--- a/lua/entities/acf_receiver/init.lua
+++ b/lua/entities/acf_receiver/init.lua
@@ -215,6 +215,10 @@ do -- Spawn and Update functions
 
 	Entities.Register("acf_receiver", ACF.MakeReceiver, "Receiver")
 
+	-- Compatibility with ACE receiver entities
+	Entities.Register("ace_rwr_dir", ACF.MakeReceiver, "Receiver")
+	Entities.Register("ace_rwr_sphere", ACF.MakeReceiver, "Receiver")
+
 	------------------- Updating ---------------------
 
 	function ENT:Update(Data)

--- a/lua/entities/acf_receiver/init.lua
+++ b/lua/entities/acf_receiver/init.lua
@@ -41,7 +41,7 @@ local function CheckReceive(Entity)
 	local Origin = Entity:LocalToWorld(Entity.Origin)
 
 	for Ent in pairs(Sources) do
-		local EntPos = Ent.Position or Ent:GetPos()
+		local EntPos = Ent.ACF_Position or Ent:GetPos()
 		local EntDamage = Entity.Damage
 		local Spread = math.max(Entity.Divisor, 15) * 2 * EntDamage
 


### PR DESCRIPTION
- Autoloaders now ignore multiple mount point racks
- Fix cam controller naming conflict in radar entity tracking
- Some limited cross compatibility for ACE radar/receiver entities
- Compatibility with ACF-3 breaking changes (Aliasing redesign)
- Optimize entity_tracking_sv as much as possible (see 1.)
- Switch GetContraption to CFW_GetContraption to prepare for CFW breaking change
- Ponder naming support by @cacahuateestilojapones

1. This is still having problems, but at this point it might be a CFW issue. Basically, garbage contraptions are building up that never get their remove function called... This is likely having a trickle down effect if its CFW's fault, so it may not be an ACF-3 Missiles thing, but its something I need to investigate further before merging probably